### PR TITLE
Allow configuration to be reset to original values. Even if they are nil

### DIFF
--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -36,17 +36,16 @@ module Specinfra
 
       def method_missing(meth, val=nil)
         key = meth.to_s
-        key.gsub!(/=$/, '')
-        if ! val.nil?
-          instance_variable_set("@#{key}", val)
-          RSpec.configuration.send(:"#{key}=", val) if defined?(RSpec)
+        if key.end_with?('=')
+          RSpec.configuration.send(:"#{key}", val) if defined?(RSpec)
+          instance_variable_set("@#{key.chop}", val)
+        else
+          if defined?(RSpec) && RSpec.configuration.respond_to?(key)
+            RSpec.configuration.send(key)
+          else
+            nil
+          end
         end
-
-        ret = instance_variable_get("@#{key}")
-        if ret.nil? && defined?(RSpec) && RSpec.configuration.respond_to?(key)
-          ret = RSpec.configuration.send(key)
-        end
-        ret
       end
     end
   end

--- a/lib/specinfra/helper/set.rb
+++ b/lib/specinfra/helper/set.rb
@@ -1,5 +1,5 @@
 module Specinfra::Helper::Set
   def set(param, *value)
-    Specinfra.configuration.send(param, *value)
+    Specinfra.configuration.send("#{param}=", *value)
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -8,7 +8,24 @@ describe RSpec.configuration.path do
   it { should eq Specinfra.configuration.path }
 end
 
-Specinfra.configuration.os = 'foo'
-describe Specinfra.configuration.os do
-  it { should eq 'foo' }
+describe 'setting configuration' do
+
+  before { Specinfra.configuration.os = 'foo' }
+
+  it { expect(Specinfra.configuration.os).to eq 'foo' }
+
+end
+
+describe 're-setting configuration' do
+
+  let!(:previous_state) { Specinfra.configuration.disable_sudo }
+
+  before do
+    Specinfra.configuration.disable_sudo = true
+    Specinfra.configuration.disable_sudo = previous_state
+  end
+
+  it "it goes back to it's original state" do
+    expect(Specinfra.configuration.disable_sudo).to eq previous_state
+  end
 end


### PR DESCRIPTION
I was using this via the [nodespec gem] (https://github.com/smontanari/nodespec) and I needed to disable sudo for specific tests.

Basically I needed to do this:

- capture the current state of a config value, in my case 'disable_sudo'
- set 'disable_sudo' to true
- run some tests
- reset 'disable_sudo' to it's previous value
- continue running more tests

This didn't work as disable_sudo had it's default value of `nil` and the method_missing wouldn't set nil values. 

I wrote a breaking test for it and make it pass.

Let me know your thoughts.

Cheers,

Seb
