### PR TITLE
Fix get_sha256sum for Darwin

### DIFF
--- a/lib/specinfra/command/darwin/base/file.rb
+++ b/lib/specinfra/command/darwin/base/file.rb
@@ -9,7 +9,7 @@ class Specinfra::Command::Darwin::Base::File < Specinfra::Command::Base::File
     end
 
     def get_sha256sum(file)
-      "openssl sha256 #{escape(file)} | cut -d'=' -f2 | cut -c 2-"
+      "ruby -e \"require 'digest'; puts Digest::SHA256.hexdigest File.read '#{escape(file)}'\""
     end
 
     def check_is_linked_to(link, target)

--- a/spec/command/darwin/file_spec.rb
+++ b/spec/command/darwin/file_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'darwin'
+
+describe get_command(:get_file_sha256sum, '/etc/services') do
+  it { should eq 'ruby -e "require \'digest\'; puts Digest::SHA256.hexdigest File.read \'/etc/services\'"' }
+end
+
+describe get_command(:check_file_is_owned_by, '/tmp', 'root') do
+  it { should eq 'stat -f %Su /tmp | grep -- \\^root\\$' }
+end
+
+describe get_command(:check_file_is_grouped, '/tmp', 'wheel') do
+  it { should eq 'stat -f %Sg /tmp | grep -- \\^wheel\\$' }
+end


### PR DESCRIPTION
I have fixed get_sha256sum for Darwin because openssl command of OS X (including OS X Yosemite) don't have sha256 option.

$ openssl sha256 /etc/services 
openssl:Error: 'sha256' is an invalid command.
:

This pull request works on OS X 10.5 or later.