### PR TITLE
nslookup exit code workaround

### DIFF
--- a/lib/specinfra/command/base/host.rb
+++ b/lib/specinfra/command/base/host.rb
@@ -2,7 +2,7 @@ class Specinfra::Command::Base::Host < Specinfra::Command::Base
   class << self
     def check_is_resolvable(name, type)
       if type == "dns"
-        "nslookup -timeout=1 #{escape(name)}"
+        "lookup=$(nslookup -timeout=1 #{escape(name)} | grep -A1 'Name:' | grep Address | awk -F': ' '{print $2}'); if [ "$lookup" ]; then $(exit 0); else $(exit 1); fi"
       elsif type == "hosts"
         "grep -w -- #{escape(name)} /etc/hosts"
       else

--- a/lib/specinfra/command/base/host.rb
+++ b/lib/specinfra/command/base/host.rb
@@ -2,7 +2,7 @@ class Specinfra::Command::Base::Host < Specinfra::Command::Base
   class << self
     def check_is_resolvable(name, type)
       if type == "dns"
-        "lookup=$(nslookup -timeout=1 #{escape(name)} | grep -A1 'Name:' | grep Address | awk -F': ' '{print $2}'); if [ "$lookup" ]; then $(exit 0); else $(exit 1); fi"
+        %Q[lookup=$(nslookup -timeout=1 #{escape(name)} | grep -A1 'Name:' | grep Address | awk -F': ' '{print $2}'); if [ "$lookup" ]; then $(exit 0); else $(exit 1); fi]
       elsif type == "hosts"
         "grep -w -- #{escape(name)} /etc/hosts"
       else


### PR DESCRIPTION
I don't believe nslookup on it's own will give you the expected exit code on the latest Ubuntu 12.04. Dig behaves similarly in Ubuntu 12.04.   I have confirmed that nslookup will return 0 whether or not nslookup finds a record.  Exit codes for nslookup are fixed in Ubuntu 14.04.  

This pull request is a  proposed workaround for Ubuntu 12.04 that uses nslookup in a pipe.  
 
nslookup -timeout=1 google.com
Server:          10.0.2.3
Address:     10.0.2.3#53

Non-authoritative answer:
Name:     google.com
Address: 74.125.239.134
Name:     google.com
Address: 74.125.239.132
Name:     google.com
Address: 74.125.239.133
Name:     google.com
Address: 74.125.239.137
Name:     google.com
Address: 74.125.239.135
Name:     google.com
Address: 74.125.239.142
Name:     google.com
Address: 74.125.239.136
Name:     google.com
Address: 74.125.239.131
Name:     google.com
Address: 74.125.239.128
Name:     google.com
Address: 74.125.239.130
Name:     google.com
Address: 74.125.239.129

echo $?
0

nslookup -timeout=1 google.foo
Server:          10.0.2.3
Address:     10.0.2.3#53

** server can't find google.foo: NXDOMAIN

echo $?
0

lookup=$(nslookup -timeout=1 google.com | grep -A1 'Name:' | grep Address | awk -F': ' '{print $2}'); if [ "$lookup" ]; then $(exit 0); else $(exit 1); fi
echo $?
0

lookup=$(nslookup -timeout=1 google.foo | grep -A1 'Name:' | grep Address | awk -F': ' '{print $2}'); if [ "$lookup" ]; then $(exit 0); else $(exit 1); fi
echo $?
1

Related References:
http://www.linuxdigest.org/2012/06/a-better-nslookup/

https://bugzilla.redhat.com/show_bug.cgi?id=829829