### PR TITLE
Support routes with multiple destinations

### DIFF
--- a/lib/specinfra/command/base/routing_table.rb
+++ b/lib/specinfra/command/base/routing_table.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Base::RoutingTable < Specinfra::Command::Base
   class << self
     def check_has_entry(destination)
-      "ip route | grep -E '^#{destination} '"
+      "ip route show #{destination}"
     end
 
     alias :get_entry :check_has_entry

--- a/lib/specinfra/command/base/routing_table.rb
+++ b/lib/specinfra/command/base/routing_table.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Base::RoutingTable < Specinfra::Command::Base
   class << self
     def check_has_entry(destination)
-      "ip route show #{destination}"
+      "ip route show #{destination} | grep #{destination}"
     end
 
     alias :get_entry :check_has_entry

--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -133,31 +133,25 @@ module Specinfra
 	  :interface   => expected_attr[:interface] ? $3 : nil
 	}
       else
-        #ret.stdout =~ /^(\S+)(?: via (\S+))? dev (\S+).+\n(?:default via (\S+))?/
-        #actual_attr = {
-        #  :destination => $1,
-        #  :gateway     => $2 ? $2 : $4,
-        #  :interface   => expected_attr[:interface] ? $3 : nil
-        #}
-
-        matches = ret.scan(/^(\S+)(?: via (\S+))? dev (\S+).+\n|^(\S+).+\n|\s+nexthop via (\S+)\s+dev (\S+).+/)
+        matches = ret.stdout.scan(/^(\S+)(?: via (\S+))? dev (\S+).+\n|^(\S+).+\n|\s+nexthop via (\S+)\s+dev (\S+).+/)
         if matches.length > 1
           # ECMP route
+          destination = nil
           matches.each do |groups|
             if groups[3]
               destination = groups[3]
               next
-            elsif
-              next unless expected_attr[:interface] == groups[6]
+            else
+              next unless expected_attr[:interface] == groups[5]
             end
 
             actual_attr = {
               :destination => destination,
-              :gateway => groups[5],
-              :interface => groups[6]
+              :gateway => groups[4],
+              :interface => groups[5]
             }
           end
-        else
+        elsif matches.length == 1
           # Non-ECMP route
           groups = matches[0]
           actual_attr = {

--- a/lib/specinfra/processor.rb
+++ b/lib/specinfra/processor.rb
@@ -133,12 +133,40 @@ module Specinfra
 	  :interface   => expected_attr[:interface] ? $3 : nil
 	}
       else
-        ret.stdout =~ /^(\S+)(?: via (\S+))? dev (\S+).+\n(?:default via (\S+))?/
-        actual_attr = {
-          :destination => $1,
-          :gateway     => $2 ? $2 : $4,
-          :interface   => expected_attr[:interface] ? $3 : nil
-        }
+        #ret.stdout =~ /^(\S+)(?: via (\S+))? dev (\S+).+\n(?:default via (\S+))?/
+        #actual_attr = {
+        #  :destination => $1,
+        #  :gateway     => $2 ? $2 : $4,
+        #  :interface   => expected_attr[:interface] ? $3 : nil
+        #}
+
+        matches = ret.scan(/^(\S+)(?: via (\S+))? dev (\S+).+\n|^(\S+).+\n|\s+nexthop via (\S+)\s+dev (\S+).+/)
+        if matches.length > 1
+          # ECMP route
+          matches.each do |groups|
+            if groups[3]
+              destination = groups[3]
+              next
+            elsif
+              next unless expected_attr[:interface] == groups[6]
+            end
+
+            actual_attr = {
+              :destination => destination,
+              :gateway => groups[5],
+              :interface => groups[6]
+            }
+          end
+        else
+          # Non-ECMP route
+          groups = matches[0]
+          actual_attr = {
+            :destination => groups[0],
+            :gateway     => groups[1] ? groups[1] : groups[3],
+            :interface   => expected_attr[:interface] ? groups[2] : nil
+          }
+        end
+
       end
 
       expected_attr.each do |key, val|


### PR DESCRIPTION
ECMP means that a route can have multiple destinations, E.g.

$ ip route show 10.2.1.4
10.2.1.4  proto zebra  metric 20
        nexthop via 10.2.1.1  dev swp49 weight 1 onlink
        nexthop via 10.2.1.1  dev swp50 weight 1 onlink
        nexthop via 10.2.1.2  dev swp51 weight 1 onlink
        nexthop via 10.2.1.2  dev swp52 weight 1 onlink

This patch modifies the routing_table resource to support the different output for multiple destination routes:

$ ip route show
default via 192.168.0.1 dev eth0
10.2.1.2  proto zebra  metric 20
	nexthop via 10.2.1.2  dev swp1 weight 1 onlink
	nexthop via 10.2.1.2  dev swp2 weight 1 onlink
	nexthop via 10.2.1.2  dev swp3 weight 1 onlink
	nexthop via 10.2.1.2  dev swp4 weight 1 onlink
10.4.1.0/25 dev br0  proto kernel  scope link  src 10.4.1.1
10.4.1.128/25 dev br1  proto kernel  scope link  src 10.4.1.129
192.168.0.0/24 dev eth0  proto kernel  scope link  src 192.168.0.11

...
Routing Table
  should have entry [:destination, "default"], [:gateway, "192.168.0.1"], and [:interface, "eth0"]

Routing Table
  should have entry [:destination, "192.168.0.0/24"] and [:interface, "eth0"]

Routing Table
  should have entry [:destination, "10.2.1.2"], [:interface, "swp1"], and [:gateway, "10.2.1.2"]