### PR TITLE
Handle NameError exception if an invalid variable name reaches method_missing

### DIFF
--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -37,14 +37,19 @@ module Specinfra
       def method_missing(meth, val=nil)
         key = meth.to_s
         key.gsub!(/=$/, '')
-        if ! val.nil?
-          instance_variable_set("@#{key}", val)
-          RSpec.configuration.send(:"#{key}=", val) if defined?(RSpec)
-        end
-
-        ret = instance_variable_get("@#{key}")
-        if ret.nil? && defined?(RSpec) && RSpec.configuration.respond_to?(key)
-          ret = RSpec.configuration.send(key)
+        ret = nil
+        begin
+          if ! val.nil?
+            instance_variable_set("@#{key}", val)
+            RSpec.configuration.send(:"#{key}=", val) if defined?(RSpec)
+          end
+          ret = instance_variable_get("@#{key}")
+        rescue NameError
+          ret = nil
+        ensure
+          if ret.nil? && defined?(RSpec) && RSpec.configuration.respond_to?(key)
+            ret = RSpec.configuration.send(key)
+          end
         end
         ret
       end


### PR DESCRIPTION
When using sprockets and specinfra together, our project would occasionally run into problems when compiling assets due to specinfra attempting to create an instance variable with an invalid name. While I'm not entirely sure *why* this behavior would occur, it was more straightforward to patch specinfra than go down the rabbit holes to determine what was causing the two libraries to occasionally not play nicely together.

This change simply wraps the calls to ```#set_instance_variable``` and ```#get_instance_variable``` in a begin/rescue block. Please let me know if you would prefer to have this fixed in a different way, and I'll be happy to update.

Thanks!