### PR TITLE
Include other systemd actions and override is_enabled check

### DIFF
--- a/lib/specinfra/command/opensuse/base/service.rb
+++ b/lib/specinfra/command/opensuse/base/service.rb
@@ -1,7 +1,12 @@
 class Specinfra::Command::Opensuse::Base::Service < Specinfra::Command::Suse::Base::Service
   class << self
+    include Specinfra::Command::Module::Systemd
     def check_is_running(service)
       "service #{escape(service)} status"
+    end
+
+    def check_is_enabled(service, level=nil)
+       "systemctl is-enabled #{escape(service)}"
     end
   end
 end


### PR DESCRIPTION
This PR adds all systemd functions to opensuse and overrides the is_enabled check to ensure
we also check for sysv style files in case we don't have a systemd service

```
$ /bin/systemctl is-enabled logstash.service
logstash.service is not a native service, redirecting to /sbin/chkconfig.
Executing /sbin/chkconfig logstash --level=5
enabled

$ /bin/systemctl is-enabled elasticsearch.service
enabled
```