### PR TITLE
Add sudo command after shell command

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -31,7 +31,9 @@ module Specinfra::Backend
 
     def build_command(cmd)
       shell = Specinfra.configuration.shell || '/bin/sh'
+      prepend = prepend_to_command
       cmd = cmd.shelljoin if cmd.is_a?(Array)
+      cmd = "#{prepend} #{cmd}" if !prepend.empty?
       cmd = "#{shell.shellescape} -c #{cmd.shellescape}"
 
       path = Specinfra.configuration.path
@@ -74,6 +76,10 @@ module Specinfra::Backend
       else
         cmd
       end
+    end
+
+    def prepend_to_command
+      ''
     end
   end
 end

--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -7,7 +7,7 @@ module Specinfra::Backend
   class Ssh < Exec
     def run_command(cmd, opt={})
       cmd = build_command(cmd)
-      cmd = add_pre_command(cmd)
+     cmd = add_pre_command(cmd)
       ret = with_env do
         ssh_exec!(cmd)
       end
@@ -31,15 +31,15 @@ module Specinfra::Backend
       scp_upload!(from, to, :recursive => true)
     end
 
-    def build_command(cmd)
-      cmd = super(cmd)
+    private
+    def prepend_to_command
       if sudo?
-        cmd = "#{sudo} -p '#{prompt}' #{cmd}"
+        "#{sudo} -p '#{prompt}'"
+      else
+        ''
       end
-      cmd
     end
 
-    private
     def prompt
       'Password: '
     end

--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -7,7 +7,7 @@ module Specinfra::Backend
   class Ssh < Exec
     def run_command(cmd, opt={})
       cmd = build_command(cmd)
-     cmd = add_pre_command(cmd)
+      cmd = add_pre_command(cmd)
       ret = with_env do
         ssh_exec!(cmd)
       end

--- a/spec/backend/ssh/build_command_spec.rb
+++ b/spec/backend/ssh/build_command_spec.rb
@@ -30,11 +30,11 @@ describe Specinfra::Backend::Ssh do
       end
 
       it 'should prepend sudo' do
-        expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq %q{sudo -p 'Password: ' /bin/sh -c test\ -f\ /etc/passwd}
+        expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq %q{/bin/sh -c sudo\ -p\ \'Password:\ \'\ test\ -f\ /etc/passwd}
       end
 
       it 'should escape special characters' do
-        expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq %q{sudo -p 'Password: ' /bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)}
+        expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq %q{/bin/sh -c sudo\ -p\ \'Password:\ \'\ test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)}
       end
     end
 
@@ -54,11 +54,11 @@ describe Specinfra::Backend::Ssh do
       end
 
       it 'command pattern 1a' do
-        expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq %q{/usr/local/bin/sudo -p 'Password: ' /bin/sh -c test\ -f\ /etc/passwd}
+        expect(Specinfra.backend.build_command('test -f /etc/passwd')).to eq %q{/bin/sh -c /usr/local/bin/sudo\ -p\ \'Password:\ \'\ test\ -f\ /etc/passwd}
       end
 
       it 'command pattern 2a' do
-        expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq %q{/usr/local/bin/sudo -p 'Password: ' /bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)}
+        expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq %q{/bin/sh -c /usr/local/bin/sudo\ -p\ \'Password:\ \'\ test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)}
       end
     end
 
@@ -83,32 +83,6 @@ describe Specinfra::Backend::Ssh do
 
       it 'command pattern 2b' do
         expect(Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)')).to eq '/bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)'
-      end
-    end
-
-    context 'with sudo on alternative path' do
-      before do
-        RSpec.configure do |c|
-          set :ssh_options, :user => 'foo'
-          c.ssh = double(:ssh, Specinfra.configuration.ssh_options)
-          c.sudo_path = nil
-        end
-      end
-
-      after do
-        RSpec.configure do |c|
-          c.sudo_options = nil
-        end
-      end
-
-      context 'command pattern 1a' do
-        subject { Specinfra.backend.build_command('test -f /etc/passwd') }
-        it { should eq %q{sudo -p 'Password: ' /bin/sh -c test\ -f\ /etc/passwd} }
-      end
-
-      context 'command pattern 2a' do
-        subject { Specinfra.backend.build_command('test ! -f /etc/selinux/config || (getenforce | grep -i -- disabled && grep -i -- ^SELINUX=disabled$ /etc/selinux/config)') }
-        it { should eq %q{sudo -p 'Password: ' /bin/sh -c test\ \!\ -f\ /etc/selinux/config\ \|\|\ \(getenforce\ \|\ grep\ -i\ --\ disabled\ \&\&\ grep\ -i\ --\ \^SELINUX\=disabled\$\ /etc/selinux/config\)} }
       end
     end
   end


### PR DESCRIPTION
I think allows for specific commands to be allowed in the sudoers file for the user who will run serverspec tests, instead of that user needing full root sudo permissions, or sudoers permission for `/bin/sh` or another shell.