### PR TITLE
Add check_is_running_under_runit.

### DIFF
--- a/lib/specinfra/command/base/service.rb
+++ b/lib/specinfra/command/base/service.rb
@@ -16,6 +16,10 @@ class Specinfra::Command::Base::Service < Specinfra::Command::Base
       "svstat /service/#{escape(service)} | grep -E 'up \\(pid [0-9]+\\)'"
     end
 
+    def check_is_running_under_runit(service)
+      "sv status #{escape(service)} | grep -E '^run: '"
+    end
+
     def check_is_monitored_by_monit(service)
       "monit status"
     end


### PR DESCRIPTION
Adds support for `should be_running.under('runit')`.  Similar to `daemontools`, except it automatically uses `/etc/service` and the output is easier to test.