### PR TITLE
Support daemontools with FreeBSD

### DIFF
--- a/lib/specinfra/command/freebsd/base/service.rb
+++ b/lib/specinfra/command/freebsd/base/service.rb
@@ -3,5 +3,9 @@ class Specinfra::Command::Freebsd::Base::Service < Specinfra::Command::Base::Ser
     def check_is_enabled(service, level=3)
       "service -e | grep -- #{escape(service)}"
     end
+
+    def check_is_running_under_daemontools(service)
+      "svstat /var/service/#{escape(service)} | grep -E 'up \\(pid [0-9]+\\)'"
+    end
   end
 end


### PR DESCRIPTION
FreeBSD's default value of svscan service directory is `/var/service`.

See also:
http://sources.freebsd.org/HEAD/ports/sysutils/daemontools/files/svscan.in

> svscan_servicedir	The directory containing the various service.
>			directories to be monitored.  Professor Daniel J.
>			Bernstein recommends "/service", but the FreeBSD
>			port has a default of "/var/service" instead