### PR TITLE
remove `-f` option from darwin get_link_target

### DIFF
--- a/lib/specinfra/command/darwin/base/file.rb
+++ b/lib/specinfra/command/darwin/base/file.rb
@@ -16,6 +16,10 @@ class Specinfra::Command::Darwin::Base::File < Specinfra::Command::Base::File
       "stat -f %Y #{escape(link)} | grep -- #{escape(target)}"
     end
 
+    def get_link_target(link)
+      "readlink #{escape(link)}"
+    end
+
     def check_has_mode(file, mode)
       regexp = "^#{mode}$"
       "stat -f%Lp #{escape(file)} | grep -- #{escape(regexp)}"


### PR DESCRIPTION
This PR removes `-f` option from `get_link_target` on darwin.
Because darwin(OSX)'s readlink differs from GNU readlink, `-f`option is unavailable.

```sh
$ readlink -f wercker.yml
readlink: illegal option -- f
usage: readlink [-n] [file ...]
```