### PR TITLE
Set logs = true when attaching to Docker backend

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -50,7 +50,7 @@ module Specinfra::Backend
       begin
         container.start
         begin
-          stdout, stderr = container.attach
+          stdout, stderr = container.attach(:logs => true)
           result = container.wait
           return CommandResult.new :stdout => stdout.join, :stderr => stderr.join,
             :exit_status => result['StatusCode']


### PR DESCRIPTION
In the Docker API v1.15 logs=true is required to capture
stdout and stderr logs

stdout - if logs=true, return stdout log, if stream=true,
attach to stdout. Default false

https://docs.docker.com/reference/api/docker_remote_api_v1.15/