### PR TITLE
Fix regex for crontab

### DIFF
--- a/lib/specinfra/command/base/cron.rb
+++ b/lib/specinfra/command/base/cron.rb
@@ -2,10 +2,11 @@ class Specinfra::Command::Base::Cron < Specinfra::Command::Base
   class << self
     def check_has_entry(user, entry)
       entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]')
+      grep_command = "grep -v '^[[:space:]]*#' | grep -- ^#{escape(entry_escaped)}$"
       if user.nil?
-        "crontab -l | grep -v '^[[:space:]]*#' -- | grep -- #{escape(entry_escaped)}"
+        "crontab -l | #{grep_command}"
       else
-        "crontab -u #{escape(user)} -l | grep -v '^[[:space:]]*#' | grep -- #{escape(entry_escaped)}"
+        "crontab -u #{escape(user)} -l | #{grep_command}"
       end
     end
   end

--- a/lib/specinfra/command/base/cron.rb
+++ b/lib/specinfra/command/base/cron.rb
@@ -3,9 +3,9 @@ class Specinfra::Command::Base::Cron < Specinfra::Command::Base
     def check_has_entry(user, entry)
       entry_escaped = entry.gsub(/\*/, '\\*').gsub(/\[/, '\\[').gsub(/\]/, '\\]')
       if user.nil?
-        "crontab -l | grep -v \"#\" -- | grep -- #{escape(entry_escaped)}"
+        "crontab -l | grep -v '^[[:space:]]*#' -- | grep -- #{escape(entry_escaped)}"
       else
-        "crontab -u #{escape(user)} -l | grep -v \"#\" | grep -- #{escape(entry_escaped)}"
+        "crontab -u #{escape(user)} -l | grep -v '^[[:space:]]*#' | grep -- #{escape(entry_escaped)}"
       end
     end
   end


### PR DESCRIPTION
cronの確認コマンドに2点問題がありそうなので修正しました。

1つは`#`を含むエントリがコメントとみなされて

```
* * * * * command '### abc ###'
```

以下のテストがエラーになることです。

```ruby
it { should have_entry("* * * * * command '### abc ###").with_user('mikeda') }
```

もう1つはgrepに^、$が無いためこういうエントリに対して

```
10 * * * * command1 | command2
```

以下のテストが通ってしまうことです。

```ruby
describe cron do
  it { should have_entry("10 * * * * command1").with_user('mikeda') }
  it { should have_entry("0 * * * * command1 | command2").with_user('mikeda') }
end
```

2つめに関してはコマンド部分のみを確認していたユーザなど、既存テストに影響をあたえる可能性が有ります。

```ruby
describe cron do
  it { should have_entry("command1").with_user('mikeda') }
end
```