### PR TITLE
Add commands to base group

### DIFF
--- a/lib/specinfra/command/base/group.rb
+++ b/lib/specinfra/command/base/group.rb
@@ -9,6 +9,10 @@ class Specinfra::Command::Base::Group < Specinfra::Command::Base
       "getent group | grep -w -- #{escape(regexp)} | cut -f 3 -d ':' | grep -w -- #{escape(gid)}"
     end
 
+    def get_gid(group)
+      "getent group #{escape(group)} | cut -f 3 -d ':'"
+    end
+
     def add(group, options)
       command = ['groupadd']
       command << '-g' << escape(options[:gid])  if options[:gid]

--- a/lib/specinfra/command/base/group.rb
+++ b/lib/specinfra/command/base/group.rb
@@ -13,6 +13,10 @@ class Specinfra::Command::Base::Group < Specinfra::Command::Base
       "getent group #{escape(group)} | cut -f 3 -d ':'"
     end
 
+    def update_gid(group, gid)
+      "groupmod -g #{escape(gid)} #{escape(group)}"
+    end
+
     def add(group, options)
       command = ['groupadd']
       command << '-g' << escape(options[:gid])  if options[:gid]

--- a/lib/specinfra/command/base/group.rb
+++ b/lib/specinfra/command/base/group.rb
@@ -8,5 +8,12 @@ class Specinfra::Command::Base::Group < Specinfra::Command::Base
       regexp = "^#{group}"
       "getent group | grep -w -- #{escape(regexp)} | cut -f 3 -d ':' | grep -w -- #{escape(gid)}"
     end
+
+    def add(group, options)
+      command = ['groupadd']
+      command << '-g' << escape(options[:gid])  if options[:gid]
+      command << escape(group)
+      command.join(' ')
+    end
   end
 end

--- a/spec/command/base/group_spec.rb
+++ b/spec/command/base/group_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+set :os, { :family => nil }
+
+describe get_command(:add_group, 'foo', :gid => 1234) do
+  it { should eq 'groupadd -g 1234 foo' }
+end
+

--- a/spec/command/base/group_spec.rb
+++ b/spec/command/base/group_spec.rb
@@ -2,6 +2,10 @@ require 'spec_helper'
 
 set :os, { :family => nil }
 
+describe get_command(:get_group_gid, 'foo') do
+  it { should eq "getent group foo | cut -f 3 -d ':'" }
+end
+
 describe get_command(:add_group, 'foo', :gid => 1234) do
   it { should eq 'groupadd -g 1234 foo' }
 end

--- a/spec/command/base/group_spec.rb
+++ b/spec/command/base/group_spec.rb
@@ -6,6 +6,10 @@ describe get_command(:get_group_gid, 'foo') do
   it { should eq "getent group foo | cut -f 3 -d ':'" }
 end
 
+describe get_command(:update_group_gid, 'foo', 1234) do
+  it { should eq "groupmod -g 1234 foo" }
+end
+
 describe get_command(:add_group, 'foo', :gid => 1234) do
   it { should eq 'groupadd -g 1234 foo' }
 end


### PR DESCRIPTION
Add 3 commands to base group:

- `add_group` - Create new group
- `get_group_gid` - Get gid from group's name
- `update_group_gid` - Update group's gid