### PR TITLE
Support host_inventory['platform'] and host_inventory['platform_version']

### DIFF
--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -3,6 +3,8 @@ require 'specinfra/host_inventory/ec2'
 require 'specinfra/host_inventory/hostname'
 require 'specinfra/host_inventory/domain'
 require 'specinfra/host_inventory/fqdn'
+require 'specinfra/host_inventory/platform'
+require 'specinfra/host_inventory/platform_version'
 
 module Specinfra
   class HostInventory

--- a/lib/specinfra/host_inventory/platform.rb
+++ b/lib/specinfra/host_inventory/platform.rb
@@ -1,0 +1,9 @@
+module Specinfra
+  class HostInventory
+    class Platform
+      def self.get
+        os[:family]
+      end
+    end
+  end
+end

--- a/lib/specinfra/host_inventory/platform_version.rb
+++ b/lib/specinfra/host_inventory/platform_version.rb
@@ -1,0 +1,15 @@
+module Specinfra
+  class HostInventory
+    class PlatformVersion
+      def self.get
+        os[:release]
+      end
+    end
+  end
+end
+
+
+
+
+
+


### PR DESCRIPTION
You can get `host_inventory['platform']` and `host_inventory['platform_version']` with this fix.

`host_inventory['platform']` is not compatible with Ohai, for example, it returns `redhat` with CentOS or other Red Hat based Linux.
