### PR TITLE
Support getting filesystem information

### DIFF
--- a/lib/specinfra/command/linux/base/inventory.rb
+++ b/lib/specinfra/command/linux/base/inventory.rb
@@ -15,5 +15,9 @@ class Specinfra::Command::Linux::Base::Inventory < Specinfra::Command::Base::Inv
     def get_fqdn
       'hostname -f'
     end
+
+    def get_filesystem
+      'df -P'
+    end
   end
 end

--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -5,6 +5,7 @@ require 'specinfra/host_inventory/domain'
 require 'specinfra/host_inventory/fqdn'
 require 'specinfra/host_inventory/platform'
 require 'specinfra/host_inventory/platform_version'
+require 'specinfra/host_inventory/filesystem'
 
 module Specinfra
   class HostInventory

--- a/lib/specinfra/host_inventory/filesystem.rb
+++ b/lib/specinfra/host_inventory/filesystem.rb
@@ -1,0 +1,23 @@
+module Specinfra
+  class HostInventory
+    class Filesystem
+      def self.get
+        cmd = Specinfra.command.get(:get_inventory_filesystem)
+        filesystem = {}
+        Specinfra.backend.run_command(cmd).stdout.lines do |line|
+          next if line =~ /^Filesystem\s+/
+          if line =~ /^(.+?)\s+(\d+)\s+(\d+)\s+(\d+)\s+(\d+\%)\s+(.+)$/
+            device = $1
+            filesystem[device] = {}
+            filesystem[device]['kb_size'] = $2
+            filesystem[device]['kb_used'] = $3
+            filesystem[device]['kb_available'] = $4
+            filesystem[device]['percent_used'] = $5
+            filesystem[device]['mount'] = $6
+          end
+        end
+        filesystem
+      end
+    end
+  end
+end


### PR DESCRIPTION
You can get filesystem information like this.

```ruby
[3] pry(main)> host_inventory['filesystem']
=> {"/dev/mapper/VolGroup-lv_root"=>
  {"kb_size"=>"39841176",
   "kb_used"=>"1565824",
   "kb_available"=>"36251520",
   "percent_used"=>"5%",
   "mount"=>"/"},
 "tmpfs"=>
  {"kb_size"=>"234724",
   "kb_used"=>"0",
   "kb_available"=>"234724",
   "percent_used"=>"0%",
   "mount"=>"/dev/shm"},
 "/dev/sda1"=>
  {"kb_size"=>"495844",
   "kb_used"=>"31887",
   "kb_available"=>"438357",
   "percent_used"=>"7%",
   "mount"=>"/boot"},
 "vagrant"=>
  {"kb_size"=>"244277768",
   "kb_used"=>"205117140",
   "kb_available"=>"39160628",
   "percent_used"=>"84%",
   "mount"=>"/vagrant"}}
```

Support only Linux currently.
