### PR TITLE
Check runlevel in upstart service enabled

### DIFF
--- a/lib/specinfra/command/debian/base/service.rb
+++ b/lib/specinfra/command/debian/base/service.rb
@@ -2,7 +2,7 @@ class Specinfra::Command::Debian::Base::Service < Specinfra::Command::Linux::Bas
   class << self
     def check_is_enabled(service, level=3)
       # Until everything uses Upstart, this needs an OR.
-      "ls /etc/rc#{level}.d/ | grep -- '^S..#{escape(service)}' || grep 'start on' /etc/init/#{escape(service)}.conf"
+      "ls /etc/rc#{level}.d/ | grep -- '^S..#{escape(service)}' || grep 'start on.*#{level}' /etc/init/#{escape(service)}.conf"
     end
 
     def enable(service)


### PR DESCRIPTION
We amended an upstart script to not start by changing it to "start on []" instead of removing the "start on" line, added a serverspec test to expect(service 'foo').to_not be_enabled, but the test failed because it matched "start on" in the upstart script. 

I then added "expect(service 'foo').to_not be_enabled.with_level(2)" as a workaround, but noticed that didn't seem to work either.

This change request attempts to match a specific runlevel in the upstart script on the "start on" line.

To the best of my brief readings about upstart and observations with our upstart script amendment, "start on []" does not enable that service for any runlevel. I could be very wrong about this.