### PR TITLE
allow quotes around mail_alias targets

### DIFF
--- a/lib/specinfra/command/base/mail_alias.rb
+++ b/lib/specinfra/command/base/mail_alias.rb
@@ -1,8 +1,8 @@
 class Specinfra::Command::Base::MailAlias < Specinfra::Command::Base
   class << self
     def check_is_aliased_to(mail_alias, recipient)
-      recipient = "[[:space:]]#{recipient}"
-      "getent aliases #{escape(mail_alias)} | grep -- #{escape(recipient)}$"
+      recipient = "[[:space:]]([\"']?)#{recipient}\\1"
+      "getent aliases #{escape(mail_alias)} | egrep -- #{escape(recipient)}$"
     end
 
     def add(mail_alias, recipient)


### PR DESCRIPTION
this pr makes serverspec correctly identify alias targets that are enclosed in either single or double quotes.
The chef community cookbook for postfix set aliases this way, for example.
