### PR TITLE
Add the check_is_owned_by method back into windows

### DIFF
--- a/lib/specinfra/command/windows/base/file.rb
+++ b/lib/specinfra/command/windows/base/file.rb
@@ -91,6 +91,12 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
       Backend::PowerShell::Command.new { exec cmd }
     end
 
+    def check_is_owned_by(file, owner)
+      Backend::PowerShell::Command.new do
+        exec %Q!(gci #{file}).GetAccessControl().Owner -eq '#{owner}'!
+      end
+    end
+
     private
     def item_has_attribute item, attribute
       %Q!((Get-Item -Path "#{item}" -Force).attributes.ToString() -Split ', ') -contains '#{attribute}'!


### PR DESCRIPTION
This fundamentally broke after changing from version 1 in our implementation.  This is more exact than the previous as it will require the 'Group\User'