### PR TITLE
Fix issue when duplicate owners are present on file as is possible in windows

### DIFF
--- a/lib/specinfra/command/windows/base/file.rb
+++ b/lib/specinfra/command/windows/base/file.rb
@@ -93,7 +93,8 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
 
     def check_is_owned_by(file, owner)
       Backend::PowerShell::Command.new do
-        exec %Q!(gci #{file}).GetAccessControl().Owner -eq '#{owner}'!
+        exec "if((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}'
+          -or ((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}').Length -gt 0){ exit 0 } else { exit 1 }"
       end
     end
 


### PR DESCRIPTION
Also found that with 2003 and 2008 it was not exiting properly unless PowerShell v3+ was installed.  This improved way works with Powershell v2