### PR TITLE
easier way of obtaining speed in linux 

### DIFF
--- a/lib/specinfra/command/linux/base/interface.rb
+++ b/lib/specinfra/command/linux/base/interface.rb
@@ -5,7 +5,7 @@ class Specinfra::Command::Linux::Base::Interface < Specinfra::Command::Base::Int
     end
 
     def get_speed_of(name)
-      "ethtool #{name} | grep Speed | gawk '{print gensub(/Speed: ([0-9]+)Mb\\\/s/,\"\\\\1\",\"\")}'"
+      "cat /sys/class/net/#{name}/speed"
     end
 
     def check_has_ipv4_address(interface, ip_address)


### PR DESCRIPTION
works on any physical port by getting speed value from /sys/class/net
value is in MB.
port must be activated i.e `ip link set <dev> up` before variable shows up.
confirmed to work on ubuntu/debian/centos/cumulus linux