### PR TITLE
Add check for if a ruby is installed by RVM

### DIFF
--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -7,6 +7,13 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
       cmd
     end
 
+    def check_is_installed_by_rvm(name, version=nil)
+      regexp = "^#{name}"
+      cmd = "rvm list strings | grep -iw -- #{escape(regexp)}"
+      cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
+      cmd
+    end
+
     def check_is_installed_by_npm(name, version=nil)
       cmd = "npm ls #{escape(name)} -g"
       cmd = "#{cmd} | grep -w -- #{escape(version)}" if version

--- a/spec/command/base/package_spec.rb
+++ b/spec/command/base/package_spec.rb
@@ -5,3 +5,7 @@ set :os, { :family => nil }
 describe get_command(:check_package_is_installed_by_gem, 'serverspec', '2.0.0') do
   it { should eq 'gem list --local | grep -iw -- \\^serverspec | grep -w -- "[( ]2.0.0[,)]"' }
 end
+
+describe get_command(:check_package_is_installed_by_rvm, 'rbx', '2.4.1') do
+  it { should eq 'rvm list strings | grep -iw -- \\^rbx | grep -w -- 2.4.1' }
+end


### PR DESCRIPTION
This pull request lets you check if a ruby is installed by RVM, e.g. ruby 2.2.0, rbx 2.4.1, jruby 1.6.8, etc.

It can be used in serverspec like this:
```
describe package('ruby') do
  it { should be_installed.by('rvm').with_version('2.2.0') }
end

describe package('ruby') do
  it { should_not be_installed.by('rvm').with_version('1.8.7') }
end
```

I am also opening a pull request for the serverspec/serverspec repo, adding some tests there.