### PR TITLE
fix check_is_owned_by method for windows

### DIFF
--- a/lib/specinfra/command/windows/base/file.rb
+++ b/lib/specinfra/command/windows/base/file.rb
@@ -93,8 +93,7 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
 
     def check_is_owned_by(file, owner)
       Backend::PowerShell::Command.new do
-        exec "if((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}'
-          -or ((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}').Length -gt 0){ exit 0 } else { exit 1 }"
+        exec "$(if((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}' -or ((Get-Item '#{file}').GetAccessControl().Owner -match '#{owner}').Length -gt 0){ 0 } else { 1 })"
       end
     end
 


### PR DESCRIPTION
- don't break over the line
- use $() to fix
   "The term 'if' is not recognized as the name of a cmdlet, function,
  script file,"
  reference:
  https://social.technet.microsoft.com/Forums/windowsserver/en-US/d7cd6096-00c5-46d9-882d-29ae38ade748/why-does-if1-eq-1yes-failed-with-the-term-if-is-not-recognized-as-the-name-of-a?forum=winserverpowershell