### PR TITLE
Fixed rpm's version check allows partial matching.

### DIFF
--- a/lib/specinfra/command/redhat/base/package.rb
+++ b/lib/specinfra/command/redhat/base/package.rb
@@ -3,7 +3,7 @@ class Specinfra::Command::Redhat::Base::Package < Specinfra::Command::Linux::Bas
     def check_is_installed(package, version=nil)
       cmd = "rpm -q #{escape(package)}"
       if version
-        cmd = "#{cmd} | grep -w -- #{escape(version)}"
+        cmd = "#{cmd} | grep -w -- #{escape(package)}-#{escape(version)}"
       end
       cmd
     end


### PR DESCRIPTION
<pre>
describe package('foo') do
  be_installed_by("rpm").with_version("1.1")
end
</pre>

This code should match foo-1.1 or foo-1.1.x, etc... 
But current code match foo-0.1.1 , foo-2.1.1.

Please fixed it. 