### PR TITLE
Add `-m` to `useradd` options

### DIFF
--- a/lib/specinfra/command/base/user.rb
+++ b/lib/specinfra/command/base/user.rb
@@ -55,6 +55,7 @@ class Specinfra::Command::Base::User < Specinfra::Command::Base
       command << '-g' << escape(options[:gid])            if options[:gid]
       command << '-d' << escape(options[:home_directory]) if options[:home_directory]
       command << '-p' << escape(options[:password])       if options[:password]
+      command << '-m' if options[:create_home]
       command << '-r' if options[:system_user]
       command << '-u' << escape(options[:uid])            if options[:uid]
       command << escape(user)

--- a/spec/command/base/user_spec.rb
+++ b/spec/command/base/user_spec.rb
@@ -22,8 +22,8 @@ describe get_command(:update_user_gid, 'foo', 100) do
   it { should eq 'usermod -g 100 foo' }
 end
 
-describe get_command(:add_user, 'foo', :home_directory => '/home/foo', :password => '$6$foo/bar') do
-  it { should eq 'useradd -d /home/foo -p \$6\$foo/bar foo' }
+describe get_command(:add_user, 'foo', :home_directory => '/home/foo', :password => '$6$foo/bar', :create_home => true) do
+  it { should eq 'useradd -d /home/foo -p \$6\$foo/bar -m foo' }
 end
 
 describe get_command(:update_user_encrypted_password, 'foo', 'xxxxxxxx') do


### PR DESCRIPTION
If `useradd` doesn't have `-m` option, `useradd` will not create home directory on Debian-based Linux and will create on RHEL-based Linux.
Because `CREATE_HOME` of `/etc/login.def` on RHEL-based Linux is set to yes as default.
So, `useradd` should have `:create_home` to add `-m`.

Do you think about?