### PR TITLE
Support host_inventory['cpu']

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,7 @@ if defined?(RSpec)
   task :spec => 'spec:all'
 
   namespace :spec do
-    task :all => [ :helper, :backend, :configuration, :command ]
+    task :all => [ :helper, :backend, :configuration, :command, :host_inventory ]
 
     RSpec::Core::RakeTask.new(:helper) do |t|
       t.pattern = "spec/helper/*_spec.rb"
@@ -34,6 +34,10 @@ if defined?(RSpec)
 
     RSpec::Core::RakeTask.new(:command) do |t|
       t.pattern = "spec/command/**/*.rb"
+    end
+
+    RSpec::Core::RakeTask.new(:host_inventory) do |t|
+      t.pattern = "spec/host_inventory/*_spec.rb"
     end
   end
 end

--- a/lib/specinfra/command/linux/base/inventory.rb
+++ b/lib/specinfra/command/linux/base/inventory.rb
@@ -4,6 +4,10 @@ class Specinfra::Command::Linux::Base::Inventory < Specinfra::Command::Base::Inv
       'cat /proc/meminfo'
     end
 
+    def get_cpu
+      'cat /proc/cpuinfo'
+    end
+
     def get_hostname
       'hostname -s'
     end

--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -6,6 +6,7 @@ require 'specinfra/host_inventory/fqdn'
 require 'specinfra/host_inventory/platform'
 require 'specinfra/host_inventory/platform_version'
 require 'specinfra/host_inventory/filesystem'
+require 'specinfra/host_inventory/cpu'
 
 module Specinfra
   class HostInventory

--- a/lib/specinfra/host_inventory/cpu.rb
+++ b/lib/specinfra/host_inventory/cpu.rb
@@ -1,0 +1,72 @@
+module Specinfra
+  class HostInventory
+    class Cpu
+      def self.get
+        cmd = Specinfra.command.get(:get_inventory_cpu)
+        ret = Specinfra.backend.run_command(cmd).stdout
+        parse(ret)
+      end
+      def self.parse(cmd_ret)
+        cpuinfo = {}
+        cpus = cmd_ret.split(/[^^]processor/)
+        cpus.each_with_index do |cpu, idx|
+          idx = idx.to_s
+          cpuinfo[idx] = {}
+          cpu.each_line do |line|
+            case line
+            when /^vendor_id\s*:\s+(.+)$/
+              cpuinfo[idx]['vendor_id'] = $1
+            when /^cpu family\s*:\s+(\d+)$/
+              cpuinfo[idx]['cpu_family'] = $1
+            when /^model\s*:\s+(\d+)$/
+              cpuinfo[idx]['model'] = $1
+            when /^model\sname\s*:\s+(.+)$/
+              cpuinfo[idx]['model_name'] = $1
+            when /^stepping\s*:\s+(\d+)$/
+              cpuinfo[idx]['stepping'] = $1
+            when /^microcode\s*:\s+(.+)$/
+              cpuinfo[idx]['microcode'] = $1
+            when /^cpu MHz\s*:\s+(.+)$/
+              cpuinfo[idx]['cpu_mhz'] = $1
+            when /^cache size\s*:\s+(\d+) (.+)$/
+              cpuinfo[idx]['cache_size'] = "#{$1}#{$2}"
+            when /^physical id\s*:\s+(\d+)$/
+              cpuinfo[idx]['physical_id'] = $1
+            when /^siblings\s*:\s+(\d+)$/
+              cpuinfo[idx]['siblings'] = $1
+            when /^core id\s*:\s+(\d+)$/
+              cpuinfo[idx]['core_id'] = $1
+            when /^cpu cores\s*:\s+(\d+)$/
+              cpuinfo[idx]['cpu_cores'] = $1
+            when /^apicid\s*:\s+(\d+)$/
+              cpuinfo[idx]['apicid'] = $1
+            when /^initial apicid\s*:\s+(\d+)$/
+              cpuinfo[idx]['initial_apicid'] = $1
+            when /^fpu\s*:\s+(.+)$/
+              cpuinfo[idx]['fpu'] = $1
+            when /^fpu_exception\s*:\s+(.+)$/
+              cpuinfo[idx]['fpu_exception'] = $1
+            when /^cpuid level\s*:\s+(\d+)$/
+              cpuinfo[idx]['cpuid_level'] = $1
+            when /^wp\s*:\s+(.+)$/
+              cpuinfo[idx]['wp'] = $1
+            when /^flags\s*:\s+(.+)$/
+              cpuinfo[idx]['flags'] = $1.split(/\s/)
+            when /^bogomips\s*:\s+(.+)$/
+              cpuinfo[idx]['bogomips'] = $1
+            when /^clflush size\s*:\s+(\d+)$/
+              cpuinfo[idx]['clflush_size'] = $1
+            when /^cache_alignment\s*:\s+(\d+)$/
+              cpuinfo[idx]['cache_alignment'] = $1
+            when /^address sizes\s*:\s+(.+)$/
+              cpuinfo[idx]['address_sizes'] = $1
+            when /^power management\s*:\s+(.*)$/
+              cpuinfo[idx]['power_management'] = $1
+            end
+          end
+        end
+        cpuinfo
+      end
+    end
+  end
+end

--- a/lib/specinfra/host_inventory/cpu.rb
+++ b/lib/specinfra/host_inventory/cpu.rb
@@ -9,6 +9,7 @@ module Specinfra
       def self.parse(cmd_ret)
         cpuinfo = {}
         cpus = cmd_ret.split(/[^^]processor/)
+        cpuinfo['total'] = cpus.length.to_s
         cpus.each_with_index do |cpu, idx|
           idx = idx.to_s
           cpuinfo[idx] = {}

--- a/spec/command/linux/inventory_spec.rb
+++ b/spec/command/linux/inventory_spec.rb
@@ -5,3 +5,7 @@ set :os, :family => 'linux'
 describe get_command(:get_inventory_memory) do
   it { should eq 'cat /proc/meminfo' }
 end
+
+describe get_command(:get_inventory_cpu) do
+  it { should eq 'cat /proc/cpuinfo' }
+end

--- a/spec/host_inventory/cpu_spec.rb
+++ b/spec/host_inventory/cpu_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+require 'json'
+
+str = <<-EOH
+processor	: 0
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz
+stepping	: 3
+microcode	: 0x19
+cpu MHz		: 3132.076
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 2
+core id		: 0
+cpu cores	: 2
+apicid		: 0
+initial apicid	: 0
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 5
+wp		: yes
+flags		: fpu vme de pse
+bogomips	: 6264.15
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+
+processor	: 1
+vendor_id	: GenuineIntel
+cpu family	: 6
+model		: 60
+model name	: Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz
+stepping	: 3
+microcode	: 0x19
+cpu MHz		: 3132.076
+cache size	: 6144 KB
+physical id	: 0
+siblings	: 2
+core id		: 1
+cpu cores	: 2
+apicid		: 1
+initial apicid	: 1
+fpu		: yes
+fpu_exception	: yes
+cpuid level	: 5
+wp		: yes
+flags		: fpu vme de
+bogomips	: 6264.15
+clflush size	: 64
+cache_alignment	: 64
+address sizes	: 39 bits physical, 48 bits virtual
+power management:
+EOH
+
+describe Specinfra::HostInventory::Cpu do
+  describe 'Example of Ubuntu 14.04.1 LTS Kernel version 3.13.11' do
+    ret = Specinfra::HostInventory::Cpu.parse(str)
+    example do
+      expect(ret["0"]).to include(
+        "vendor_id" => "GenuineIntel",
+        "cpu_family" => "6",
+        "model" => "60",
+        "model_name" => "Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz",
+        "stepping" => "3",
+        "microcode" => "0x19",
+        "cpu_mhz" => "3132.076",
+        "cache_size" => "6144KB",
+        "physical_id" => "0",
+        "siblings" => "2",
+        "core_id" => "0",
+        "cpu_cores" => "2",
+        "apicid" => "0",
+        "initial_apicid" => "0",
+        "fpu" => "yes",
+        "fpu_exception" => "yes",
+        "cpuid_level" => "5",
+        "wp" => "yes",
+        "flags" => ["fpu", "vme", "de", "pse"],
+        "bogomips" => "6264.15",
+        "clflush_size" => "64",
+        "cache_alignment" => "64",
+        "address_sizes" => "39 bits physical, 48 bits virtual",
+        "power_management" => "",
+      )
+    end
+
+    example do
+      expect(ret["1"]).to include(
+        "vendor_id" => "GenuineIntel",
+        "cpu_family" => "6",
+        "model" => "60",
+        "model_name" => "Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz",
+        "stepping" => "3",
+        "microcode" => "0x19",
+        "cpu_mhz" => "3132.076",
+        "cache_size" => "6144KB",
+        "physical_id" => "0",
+        "siblings" => "2",
+        "core_id" => "1",
+        "cpu_cores" => "2",
+        "apicid" => "1",
+        "initial_apicid" => "1",
+        "fpu" => "yes",
+        "fpu_exception" => "yes",
+        "cpuid_level" => "5",
+        "wp" => "yes",
+        "flags" => ["fpu", "vme", "de"],
+        "bogomips" => "6264.15",
+        "clflush_size" => "64",
+        "cache_alignment" => "64",
+        "address_sizes" => "39 bits physical, 48 bits virtual",
+        "power_management" => "",
+      )
+    end
+  end
+end

--- a/spec/host_inventory/cpu_spec.rb
+++ b/spec/host_inventory/cpu_spec.rb
@@ -115,5 +115,9 @@ describe Specinfra::HostInventory::Cpu do
         "power_management" => "",
       )
     end
+
+    example do
+      expect(ret["total"]).to eq "2"
+    end
   end
 end

--- a/spec/host_inventory/cpu_spec.rb
+++ b/spec/host_inventory/cpu_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'json'
 
 str = <<-EOH
 processor	: 0
@@ -83,7 +82,7 @@ describe Specinfra::HostInventory::Cpu do
         "clflush_size" => "64",
         "cache_alignment" => "64",
         "address_sizes" => "39 bits physical, 48 bits virtual",
-        "power_management" => "",
+        "power_management" => ""
       )
     end
 
@@ -112,7 +111,7 @@ describe Specinfra::HostInventory::Cpu do
         "clflush_size" => "64",
         "cache_alignment" => "64",
         "address_sizes" => "39 bits physical, 48 bits virtual",
-        "power_management" => "",
+        "power_management" => ""
       )
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require 'specinfra'
 require 'rspec/mocks/standalone'
 require 'rspec/its'
 require 'specinfra/helper/set'
+require 'specinfra/helper/host_inventory'
 include Specinfra::Helper::Set
 
 set :backend, :exec


### PR DESCRIPTION
Add cpu information to `host_inventory` (like Ohai)

Example:
```shell
$ cat /proc/cpuinfo
processor	: 0
vendor_id	: GenuineIntel
cpu family	: 6
model		: 60
model name	: Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz
stepping	: 3
microcode	: 0x19
cpu MHz		: 3132.076
cache size	: 6144 KB
physical id	: 0
siblings	: 2
core id		: 0
cpu cores	: 2
apicid		: 0
initial apicid	: 0
fpu		: yes
fpu_exception	: yes
cpuid level	: 5
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx rdtscp lm constant_tsc rep_good nopl pni ssse3 lahf_lm
bogomips	: 6264.15
clflush size	: 64
cache_alignment	: 64
address sizes	: 39 bits physical, 48 bits virtual
power management:

processor	: 1
vendor_id	: GenuineIntel
cpu family	: 6
model		: 60
model name	: Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz
stepping	: 3
microcode	: 0x19
cpu MHz		: 3132.076
cache size	: 6144 KB
physical id	: 0
siblings	: 2
core id		: 1
cpu cores	: 2
apicid		: 1
initial apicid	: 1
fpu		: yes
fpu_exception	: yes
cpuid level	: 5
wp		: yes
flags		: fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush mmx fxsr sse sse2 ht syscall nx rdtscp lm constant_tsc rep_good nopl pni ssse3 lahf_lm
bogomips	: 6264.15
clflush size	: 64
cache_alignment	: 64
address sizes	: 39 bits physical, 48 bits virtual
power management:
```

```shell
[2] pry(main)> host_inventory['cpu']
=> {"total"=>"2",
 "0"=>
  {"vendor_id"=>"GenuineIntel",
   "cpu_family"=>"6",
   "model"=>"60",
   "model_name"=>"Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz",
   "stepping"=>"3",
   "microcode"=>"0x19",
   "cpu_mhz"=>"3132.076",
   "cache_size"=>"6144KB",
   "physical_id"=>"0",
   "siblings"=>"2",
   "core_id"=>"0",
   "cpu_cores"=>"2",
   "apicid"=>"0",
   "initial_apicid"=>"0",
   "fpu"=>"yes",
   "fpu_exception"=>"yes",
   "cpuid_level"=>"5",
   "wp"=>"yes",
   "flags"=>
    ["fpu",
     "vme",
     "de",
     "pse",
     "tsc",
     "msr",
     "pae",
     "mce",
     "cx8",
     "apic",
     "sep",
     "mtrr",
     "pge",
     "mca",
     "cmov",
     "pat",
     "pse36",
     "clflush",
     "mmx",
     "fxsr",
     "sse",
     "sse2",
     "ht",
     "syscall",
     "nx",
     "rdtscp",
     "lm",
     "constant_tsc",
     "rep_good",
    "nopl",
     "pni",
     "ssse3",
     "lahf_lm"],
   "bogomips"=>"6264.15",
   "clflush_size"=>"64",
   "cache_alignment"=>"64",
   "address_sizes"=>"39 bits physical, 48 bits virtual",
   "power_management"=>""},
 "1"=>
  {"vendor_id"=>"GenuineIntel",
   "cpu_family"=>"6",
   "model"=>"60",
   "model_name"=>"Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz",
   "stepping"=>"3",
   "microcode"=>"0x19",
   "cpu_mhz"=>"3132.076",
   "cache_size"=>"6144KB",
   "physical_id"=>"0",
   "siblings"=>"2",
   "core_id"=>"1",
   "cpu_cores"=>"2",
   "apicid"=>"1",
   "initial_apicid"=>"1",
   "fpu"=>"yes",
   "fpu_exception"=>"yes",
   "cpuid_level"=>"5",
   "wp"=>"yes",
   "flags"=>
    ["fpu",
     "vme",
     "de",
     "pse",
     "tsc",
     "msr",
     "pae",
     "mce",
     "cx8",
     "apic",
     "sep",
     "mtrr",
     "pge",
     "mca",
     "cmov",
     "pat",
     "pse36",
     "clflush",
     "mmx",
     "fxsr",
     "sse",
     "sse2",
     "ht",
     "syscall",
     "nx",
     "rdtscp",
     "lm",
     "constant_tsc",
     "rep_good",
     "nopl",
     "pni",
     "ssse3",
     "lahf_lm"],
   "bogomips"=>"6264.15",
   "clflush_size"=>"64",
   "cache_alignment"=>"64",
   "address_sizes"=>"39 bits physical, 48 bits virtual",
   "power_management"=>""}}
```