### PR TITLE
Set Cmd for container in create_and_start_container if image has none

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -50,6 +50,10 @@ module Specinfra::Backend
     def create_and_start_container
       opts = { 'Image' => current_image.id }
 
+     if current_image.json["Cmd"].nil?
+          opts.merge!({'Cmd' => ['/bin/sh', '-c', 'read'], 'OpenStdin' => true})
+      end
+
       if path = Specinfra.configuration.path
         (opts['Env'] ||= {})['PATH'] = path
       end


### PR DESCRIPTION
create_and_start_container is failing for docker images without CMD or ENTRYPOINT (base images for example)

/bin/sh is present almost in any image, except scratch, so i suggest to use it's internal command "read" to start container and wait if cmd is nil for image