### PR TITLE
runlevel check in upstart is broken

### DIFF
--- a/lib/specinfra/command/debian/base/service.rb
+++ b/lib/specinfra/command/debian/base/service.rb
@@ -2,7 +2,7 @@ class Specinfra::Command::Debian::Base::Service < Specinfra::Command::Linux::Bas
   class << self
     def check_is_enabled(service, level=3)
       # Until everything uses Upstart, this needs an OR.
-      "ls /etc/rc#{level}.d/ | grep -- '^S..#{escape(service)}' || grep 'start on.*#{level}' /etc/init/#{escape(service)}.conf"
+      "ls /etc/rc#{level}.d/ | grep -- '^S..#{escape(service)}' || grep 'start on' /etc/init/#{escape(service)}.conf"
     end
 
     def enable(service)


### PR DESCRIPTION
This reverts commit d73a82c2519095b1ae9aa04eaeb205308897cf3c from #309. As pointed out in the issue and comments, many upstart services don't even supply a runlevel or control startup based on some other parameter than runlevel, e.g.:

`start on virtual-filesystems` (/etc/init/udev.conf)

`start on started networking` (/etc/init/rabbitmq-server.conf)

Perhaps a separate `.with_runlevel` could be added instead, but the default check for a service enabled on ubuntu should not look for a runlevel.