### PR TITLE
Fix #325. Cmd lives under Config

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -50,8 +50,8 @@ module Specinfra::Backend
     def create_and_start_container
       opts = { 'Image' => current_image.id }
 
-     if current_image.json["Cmd"].nil?
-          opts.merge!({'Cmd' => ['/bin/sh', '-c', 'read'], 'OpenStdin' => true})
+      if current_image.json["Config"]["Cmd"].nil?
+        opts.merge!({'Cmd' => ['/bin/sh'], 'OpenStdin' => true})
       end
 
       if path = Specinfra.configuration.path


### PR DESCRIPTION
JSON payload returned from docker-api has the 'Cmd' attribute nested under 'Config'. [Here](https://github.com/serverspec/serverspec/blob/63738916c4a49edb05e3bfd4572d2d96f10ff718/spec/type/linux/docker_container_spec.rb#L23) is an example.

Fixed incorrect usage of `read` for `/bin/sh`. Instead, just open up `/bin/sh` with no command.