### PR TITLE
Change Host Inventory to enumerable

### DIFF
--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -1,16 +1,7 @@
-require 'specinfra/host_inventory/memory'
-require 'specinfra/host_inventory/ec2'
-require 'specinfra/host_inventory/hostname'
-require 'specinfra/host_inventory/domain'
-require 'specinfra/host_inventory/fqdn'
-require 'specinfra/host_inventory/platform'
-require 'specinfra/host_inventory/platform_version'
-require 'specinfra/host_inventory/filesystem'
-require 'specinfra/host_inventory/cpu'
-
 module Specinfra
   class HostInventory
     include Singleton
+    include Enumerable
 
     def initialize
       property[:host_inventory] ||= {}
@@ -29,5 +20,29 @@ module Specinfra
       end
       @inventory[key.to_sym]
     end
+
+    def each
+      keys.each do |k|
+        yield self[k]
+      end
+    end
+
+    def keys
+      %w{
+        memory
+        ec2
+        hostname
+        domain
+        fqdn
+        platform
+        platform_version
+        filesystem
+        cpu
+      }
+    end
   end
+end
+
+Specinfra::HostInventory.instance.keys.each do |k|
+  require "specinfra/host_inventory/#{k}"
 end

--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -23,6 +23,18 @@ module Specinfra
 
     def each
       keys.each do |k|
+        yield k, self[k]
+      end
+    end
+
+    def each_key
+      keys.each do |k|
+        yield k
+      end
+    end
+
+    def each_value
+      keys.each do |k|
         yield self[k]
       end
     end


### PR DESCRIPTION
Change Host Inventory to enumerable object (like Hash)

We can get all available keys and values by this feature.

Examlple:
```shell
[1] pry(main)> require 'specinfra'
=> true
[2] pry(main)> host_inventory.keys
=> ["memory", "ec2", "hostname", "domain", "fqdn", "platform", "platform_version", "filesystem", "cpu"]
[3] pry(main)> host_inventory.each{|k,v| p k,v}
"memory"
{"swap"=>{"cached"=>"0kB", "total"=>"2097148kB", "free"=>"2097148kB"}, "total"=>"4048272kB", "free"=>"1668476kB", "buffers"=>"300800kB", "cached"=>"744132kB", "active"=>"1390440kB", "inactive"=>"729700kB", "dirty"=>"0kB", "writeback"=>"0kB", "anon_pages"=>"1075204kB", "mapped"=>"238712kB", "slab"=>"189608kB", "slab_reclaimable"=>"169036kB", "slab_unreclaim"=>"20572kB", "page_tables"=>"25700kB", "nfs_unstable"=>"0kB", "bounce"=>"0kB", "commit_limit"=>"4121284kB", "committed_as"=>"3670180kB", "vmalloc_total"=>"34359738367kB", "vmalloc_used"=>"55928kB", "vmalloc_chunk"=>"34359673508kB"}
"ec2"
{}
"hostname"
"marcy-ubuntu"
"domain"
""
"fqdn"
"marcy-ubuntu"
"platform"
"ubuntu"
"platform_version"
"14.04"
"filesystem"
{"/dev/sda1"=>{"kb_size"=>"41251136", "kb_used"=>"33933516", "kb_available"=>"5581708", "percent_used"=>"86%", "mount"=>"/"}, "none"=>{"kb_size"=>"102400", "kb_used"=>"32", "kb_available"=>"102368", "percent_used"=>"1%", "mount"=>"/run/user"}, "udev"=>{"kb_size"=>"2011712", "kb_used"=>"12", "kb_available"=>"2011700", "percent_used"=>"1%", "mount"=>"/dev"}, "tmpfs"=>{"kb_size"=>"404828", "kb_used"=>"880", "kb_available"=>"403948", "percent_used"=>"1%", "mount"=>"/run"}, "vagrant"=>{"kb_size"=>"474018812", "kb_used"=>"108680120", "kb_available"=>"365338692", "percent_used"=>"23%", "mount"=>"/vagrant"}}
"cpu"
{"total"=>"2", "0"=>{"vendor_id"=>"GenuineIntel", "cpu_family"=>"6", "model"=>"60", "model_name"=>"Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz", "stepping"=>"3", "microcode"=>"0x19", "cpu_mhz"=>"3265.131", "cache_size"=>"6144KB", "physical_id"=>"0", "siblings"=>"2", "core_id"=>"0", "cpu_cores"=>"2", "apicid"=>"0", "initial_apicid"=>"0", "fpu"=>"yes", "fpu_exception"=>"yes", "cpuid_level"=>"5", "wp"=>"yes", "flags"=>["fpu", "vme", "de", "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr", "pge", "mca", "cmov", "pat", "pse36", "clflush", "mmx", "fxsr", "sse", "sse2", "ht", "syscall", "nx", "rdtscp", "lm", "constant_tsc", "rep_good", "nopl", "pni", "ssse3", "lahf_lm"], "bogomips"=>"6530.26", "clflush_size"=>"64", "cache_alignment"=>"64", "address_sizes"=>"39 bits physical, 48 bits virtual", "power_management"=>""}, "1"=>{"vendor_id"=>"GenuineIntel", "cpu_family"=>"6", "model"=>"60", "model_name"=>"Intel(R) Core(TM) i5-4590 CPU @ 3.30GHz", "stepping"=>"3", "microcode"=>"0x19", "cpu_mhz"=>"3265.131", "cache_size"=>"6144KB", "physical_id"=>"0", "siblings"=>"2", "core_id"=>"1", "cpu_cores"=>"2", "apicid"=>"1", "initial_apicid"=>"1", "fpu"=>"yes", "fpu_exception"=>"yes", "cpuid_level"=>"5", "wp"=>"yes", "flags"=>["fpu", "vme", "de", "pse", "tsc", "msr", "pae", "mce", "cx8", "apic", "sep", "mtrr", "pge", "mca", "cmov", "pat", "pse36", "clflush", "mmx", "fxsr", "sse", "sse2", "ht", "syscall", "nx", "rdtscp", "lm", "constant_tsc", "rep_good", "nopl", "pni", "ssse3", "lahf_lm"], "bogomips"=>"6530.26", "clflush_size"=>"64", "cache_alignment"=>"64", "address_sizes"=>"39 bits physical, 48 bits virtual", "power_management"=>""}}
=> ["memory", "ec2", "hostname", "domain", "fqdn", "platform", "platform_version", "filesystem", "cpu"]
```
