### PR TITLE
Add Alpine Linux support

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -91,6 +91,12 @@ require 'specinfra/command/aix/base/port'
 require 'specinfra/command/aix/base/service'
 require 'specinfra/command/aix/base/user'
 
+# Alpine (inherit Linux)
+require 'specinfra/command/alpine'
+require 'specinfra/command/alpine/base'
+require 'specinfra/command/alpine/base/package'
+require 'specinfra/command/alpine/base/process'
+
 # Arch (inherit Linux)
 require 'specinfra/command/arch'
 require 'specinfra/command/arch/base'

--- a/lib/specinfra/command/alpine.rb
+++ b/lib/specinfra/command/alpine.rb
@@ -1,0 +1,1 @@
+class Specinfra::Command::Alpine; end

--- a/lib/specinfra/command/alpine/base.rb
+++ b/lib/specinfra/command/alpine/base.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Alpine::Base < Specinfra::Command::Linux::Base
+end

--- a/lib/specinfra/command/alpine/base/package.rb
+++ b/lib/specinfra/command/alpine/base/package.rb
@@ -1,0 +1,19 @@
+class Specinfra::Command::Alpine::Base::Package < Specinfra::Command::Linux::Base::Package
+  class << self
+    def check_is_installed(package, version = nil)
+      pkg = [escape(package), version].compact.join('=')
+      "apk info -qe #{pkg}"
+    end
+
+    alias_method :check_is_installed_by_apk, :check_is_installed
+
+    def install(package, version = nil, _option = '')
+      pkg = [escape(package), version].compact.join('=')
+      "apk add -U #{pkg}"
+    end
+
+    def get_version(package, _opts = nil)
+      "apk version #{package} | tail -n1 | awk '{ print $1; }' | cut -d- -f2-"
+    end
+  end
+end

--- a/lib/specinfra/command/alpine/base/process.rb
+++ b/lib/specinfra/command/alpine/base/process.rb
@@ -1,0 +1,20 @@
+class Specinfra::Command::Alpine::Base::Process < Specinfra::Command::Base
+  class << self
+    def get(process, opts)
+      col = opts[:format].chomp('=')
+      if col == 'args'
+        "ps -o #{col} | grep #{escape(process)} | head -1"
+      else
+        "ps -o #{col},args | grep -E '\\s+#{process}' | awk '{ print $1 }' | head -1"
+      end
+    end
+
+    def check_is_running(process)
+      "ps -ocomm | grep -w -- #{escape(process)} | grep -qv grep"
+    end
+
+    def check_count(process, count)
+      "test $(ps -ocomm | grep -w -- #{escape(process)} | grep -v grep | wc -l) -eq #{escape(count)}"
+    end
+  end
+end

--- a/lib/specinfra/helper/detect_os.rb
+++ b/lib/specinfra/helper/detect_os.rb
@@ -7,6 +7,7 @@ module Specinfra::Helper
 end
 
 require 'specinfra/helper/detect_os/aix'
+require 'specinfra/helper/detect_os/alpine'
 require 'specinfra/helper/detect_os/arch'
 require 'specinfra/helper/detect_os/darwin'
 require 'specinfra/helper/detect_os/debian'

--- a/lib/specinfra/helper/detect_os/alpine.rb
+++ b/lib/specinfra/helper/detect_os/alpine.rb
@@ -1,0 +1,8 @@
+class Specinfra::Helper::DetectOs::Alpine < Specinfra::Helper::DetectOs
+  def self.detect
+    if run_command('ls /etc/alpine-release').success?
+      release = run_command('cat /etc/alpine-release').stdout
+      { :family => 'alpine', :release => release }
+    end
+  end
+end


### PR DESCRIPTION
This adds support for [Alpine Linux](https://www.alpinelinux.org). A Linux distribution that is gaining traction in the Docker community due to [the lightweight of the base image](http://gliderlabs.viewdocs.io/docker-alpine).