### PR TITLE
Docker: add docker_container_create_options option

### DIFF
--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -13,6 +13,7 @@ module Specinfra
         :sudo_path,
         :disable_sudo,
         :sudo_options,
+        :docker_container_create_options,
         :docker_image,
         :docker_url,
         :lxc,


### PR DESCRIPTION
Example:

```ruby
RSpec.configure do |config|
  config.docker_container_create_options = {
    'Cmd' => ['/usr/bin/tail', '-f', '/dev/null'] # keep-alive
  }
end
```
For all options, see: https://docs.docker.com/reference/api/docker_remote_api_v1.17/#create-a-container

In the above example, we are testing a "base image" that has no long running process, but we still want to test that the image was built according to the spec.