### PR TITLE
Add remove_package method to some Linux environments

### DIFF
--- a/lib/specinfra/command/arch/base/package.rb
+++ b/lib/specinfra/command/arch/base/package.rb
@@ -22,5 +22,9 @@ class Specinfra::Command::Arch::Base::Package < Specinfra::Command::Linux::Base:
     def sync_repos
       "pacman -Syy"
     end
+
+    def remove(package, option='')
+      "pacman -R --noconfirm #{option} #{package}"
+    end
   end
 end

--- a/lib/specinfra/command/debian/base/package.rb
+++ b/lib/specinfra/command/debian/base/package.rb
@@ -24,6 +24,10 @@ class Specinfra::Command::Debian::Base::Package < Specinfra::Command::Linux::Bas
     def get_version(package, opts=nil)
       "dpkg-query -f '${Status} ${Version}' -W #{package} | sed -n 's/^install ok installed //p'"
     end
+
+    def remove(package, option='')
+      "DEBIAN_FRONTEND='noninteractive' apt-get -y #{option} remove #{package}"
+    end
   end
 end
 

--- a/lib/specinfra/command/redhat/base/package.rb
+++ b/lib/specinfra/command/redhat/base/package.rb
@@ -22,6 +22,10 @@ class Specinfra::Command::Redhat::Base::Package < Specinfra::Command::Linux::Bas
       end
       cmd = "yum -y #{option} install #{full_package}"
     end
+
+    def remove(package, option='')
+      "yum -y #{option} remove #{package}"
+    end
   end
 end
 


### PR DESCRIPTION
I added remove_package method to implement `:remove` action to [itamae](https://github.com/itamae-kitchen/itamae) .
Here's my branch: https://github.com/itamae-kitchen/itamae/compare/master...eagletmt:remove-package

This PR adds support for pacman, apt and yum.
I've tested only pacman version for now (not tested apt and yum yet).