### PR TITLE
Improvements for smartos

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -220,6 +220,7 @@ require 'specinfra/command/solaris/v10/user'
 # SmartOS (inherit Solaris)
 require 'specinfra/command/smartos'
 require 'specinfra/command/smartos/base'
+require 'specinfra/command/smartos/base/file'
 require 'specinfra/command/smartos/base/package'
 require 'specinfra/command/smartos/base/service'
 

--- a/lib/specinfra/command/smartos/base/file.rb
+++ b/lib/specinfra/command/smartos/base/file.rb
@@ -1,11 +1,11 @@
 class Specinfra::Command::Smartos::Base::File < Specinfra::Command::Solaris::Base::File
   class << self
     def get_md5sum(file)
-      "digest -a md5 -v #{escape(file)} | cut -d '=' -f 2 |  cut -c 2-"
+      "/usr/bin/digest -a md5 -v #{escape(file)} | cut -d '=' -f 2 |  cut -c 2-"
     end
     
     def get_sha256sum(file)
-      "digest -a sha256 -v #{escape(file)} | cut -d '=' -f 2 |  cut -c 2-"
+      "/usr/bin/digest -a sha256 -v #{escape(file)} | cut -d '=' -f 2 |  cut -c 2-"
     end
   end
 end

--- a/lib/specinfra/command/smartos/base/file.rb
+++ b/lib/specinfra/command/smartos/base/file.rb
@@ -1,0 +1,11 @@
+class Specinfra::Command::Smartos::Base::File < Specinfra::Command::Solaris::Base::File
+  class << self
+    def get_md5sum(file)
+      "digest -a md5 -v #{escape(file)} | cut -d '=' -f 2 |  cut -c 2-"
+    end
+    
+    def get_sha256sum((file)
+      "digest -a sha256 -v #{escape(file)} | cut -d '=' -f 2 |  cut -c 2-"
+    end
+  end
+end

--- a/lib/specinfra/command/smartos/base/file.rb
+++ b/lib/specinfra/command/smartos/base/file.rb
@@ -4,7 +4,7 @@ class Specinfra::Command::Smartos::Base::File < Specinfra::Command::Solaris::Bas
       "digest -a md5 -v #{escape(file)} | cut -d '=' -f 2 |  cut -c 2-"
     end
     
-    def get_sha256sum((file)
+    def get_sha256sum(file)
       "digest -a sha256 -v #{escape(file)} | cut -d '=' -f 2 |  cut -c 2-"
     end
   end

--- a/lib/specinfra/command/smartos/base/package.rb
+++ b/lib/specinfra/command/smartos/base/package.rb
@@ -1,7 +1,7 @@
 class Specinfra::Command::Smartos::Base::Package < Specinfra::Command::Solaris::Base::Package
   class << self
     def check_is_installed(package, version=nil)
-      cmd = "/opt/local/bin/pkgin list 2> /dev/null | grep -qw ^#{escape(package)}"
+      cmd = "pkg_info -qE #{escape(package)}"
       if version
         cmd = "#{cmd}-#{escape(version)}"
       end
@@ -9,7 +9,7 @@ class Specinfra::Command::Smartos::Base::Package < Specinfra::Command::Solaris::
     end
 
     def get_version(package, opts=nil)
-      "pkgin list | cut -f 1 -d ' ' | grep -E '^#{escape(package)}-([^-])+$' | grep -Eo '(\\.|\\w)+$'"
+      "pkg_info -E #{escape(package)} | awk -F '-' '{print $NF}'"
     end
   end
 end

--- a/lib/specinfra/command/smartos/base/service.rb
+++ b/lib/specinfra/command/smartos/base/service.rb
@@ -1,11 +1,11 @@
 class Specinfra::Command::Smartos::Base::Service < Specinfra::Command::Solaris::Base::Service
   class << self
     def check_is_enabled(service, level=nil)
-      "svcs -l #{escape(service)} 2> /dev/null | grep -wx '^enabled.*true$'"
+      "svcs -l #{escape(service)} 2>/dev/null | grep '^enabled *true$' >/dev/null"
     end
 
     def check_is_running(service)
-      "svcs -l #{escape(service)} status 2> /dev/null |grep -wx '^state.*online$'"
+      "svcs -Ho state  #{escape(service)} 2>/dev/null |grep '^online$' >/dev/null"
     end
   end
 end


### PR DESCRIPTION
These changes fix a few issues:

- On SmartOS, the tools for checking md5 and sha256 hashes will not always be available. Instead, use the digest command.

- On SmartOS, GNU grep will not always be installed so commands like the following will fail because the '-x' flag will not be recognized:

```
cmd = "/opt/local/bin/pkgin list 2> /dev/null | grep -qw ^#{escape(package)}"
```

- Instead, use the pkg_info command to check if a package is installed (and use awk to pull out the package version)

- Similarly, the service checks will also fail if GNU grep is not available. Instead, don't rely on the '-x' flag (and use the `svcs -Ho state` command instead)
