### PR TITLE
Convert cmd to string before calling shellescape

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -32,7 +32,7 @@ module Specinfra::Backend
     def build_command(cmd)
       shell = Specinfra.configuration.shell || '/bin/sh'
       cmd = cmd.shelljoin if cmd.is_a?(Array)
-      cmd = "#{shell.shellescape} -c #{cmd.shellescape}"
+      cmd = "#{shell.shellescape} -c #{cmd.to_s.shellescape}"
 
       path = Specinfra.configuration.path
       if path


### PR DESCRIPTION
I was getting this error while running my tests:
```
NoMethodError:
       undefined method `shellescape' for #<Specinfra::Backend::PowerShell::Command:0x00000106831240>
       
     # /Users/mferreira/.vagrant.d/gems/gems/specinfra-2.19.3/lib/specinfra/backend/exec.rb:35:in `build_command'
     # /Users/mferreira/.vagrant.d/gems/gems/specinfra-2.19.3/lib/specinfra/backend/exec.rb:8:in `run_command'
     # /Users/mferreira/.vagrant.d/gems/gems/specinfra-2.19.3/lib/specinfra/runner.rb:27:in `run'
     # /Users/mferreira/.vagrant.d/gems/gems/specinfra-2.19.3/lib/specinfra/runner.rb:19:in `method_missing'
     # /Users/mferreira/.vagrant.d/gems/gems/serverspec-2.10.1/lib/serverspec/type/file.rb:18:in `directory?'
```

This PR fixes that.