### PR TITLE
Ignore comments in /etc/hosts

### DIFF
--- a/lib/specinfra/command/base/host.rb
+++ b/lib/specinfra/command/base/host.rb
@@ -4,7 +4,7 @@ class Specinfra::Command::Base::Host < Specinfra::Command::Base
       if type == "dns"
         %Q[lookup=$(nslookup -timeout=1 #{escape(name)} | grep -A1 'Name:' | grep Address | awk -F': ' '{print $2}'); if [ "$lookup" ]; then $(exit 0); else $(exit 1); fi]
       elsif type == "hosts"
-        "grep -w -- #{escape(name)} /etc/hosts"
+        "sed 's/#.*$//' /etc/hosts | grep -w -- #{escape(name)} /etc/hosts"
       else
         "getent hosts #{escape(name)}"
       end


### PR DESCRIPTION
Right now code like `expect(host('somehost')).to be_resolvable.by('hosts')` may return a false positive when finds a name in a comment line.
According to `man 5 hosts`
> Text from a "#" character until the end of the line is a comment, and is ignored.

so we should cut comments before looking up host name.