### PR TITLE
Avoid error on symbols

### DIFF
--- a/lib/specinfra/ec2_metadata.rb
+++ b/lib/specinfra/ec2_metadata.rb
@@ -15,7 +15,7 @@ module Specinfra
       if @metadata[key].nil?
         begin
           require "specinfra/ec2_metadata/#{key}"
-          inventory_class = Specinfra::Ec2Metadata.const_get(key.to_camel_case)
+          inventory_class = Specinfra::Ec2Metadata.const_get(key.to_s.to_camel_case)
           @metadata[key] = inventory_class.get
         rescue LoadError
           @metadata[key] = nil


### PR DESCRIPTION
> undefined method `to_camel_case' for :XXX:Symbol (NoMethodError)