### PR TITLE
not need to check Specinfra.configuration.env via any? in  backend/docker.rb

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -59,10 +59,8 @@ module Specinfra::Backend
         (opts['Env'] ||= []) << "PATH=#{path}"
       end
 
-      if Specinfra.configuration.env.any?
-        env = Specinfra.configuration.env.to_a.map { |v| v.join('=') }
-        opts['Env'] = opts['Env'].to_a.concat(env)
-      end
+      env = Specinfra.configuration.env.to_a.map { |v| v.join('=') }
+      opts['Env'] = opts['Env'].to_a.concat(env)
 
       opts.merge!(Specinfra.configuration.docker_container_create_options || {})
 


### PR DESCRIPTION
Default value of Specinfra.configuration.env is nil. So if env is nil, ```Specinfra.configuration.env.any?``` got NoMethodError.
And NilClass has to_a method. so not need to check it via any? method.