### PR TITLE
add get_property in Specinfra::Command::Module::Zfs

### DIFF
--- a/lib/specinfra/command/module/zfs.rb
+++ b/lib/specinfra/command/module/zfs.rb
@@ -11,4 +11,8 @@ module Specinfra::Command::Module::Zfs
     end
     commands.join(' && ')
   end
+
+  def get_property(zfs)
+    "zfs get -Hp -o property,value all #{escape(zfs)}"
+  end
 end


### PR DESCRIPTION
To implement 'its(:property)' in Serverspec::Type::Zfs,
add get_property in Specinfra::Command::Module::Zfs.