### PR TITLE
add get_property in Specinfra::Command::Solaris::Base::Service

### DIFF
--- a/lib/specinfra/command/solaris/base/service.rb
+++ b/lib/specinfra/command/solaris/base/service.rb
@@ -16,5 +16,9 @@ class Specinfra::Command::Solaris::Base::Service < Specinfra::Command::Base::Ser
       end
       commands.join(' && ')
     end
+
+    def get_property(service)
+      "svcprop -a #{escape(service)}"
+    end
   end
 end


### PR DESCRIPTION
To implement 'its(:property)' syntax to test property of Solaris service,
add get_property in Specinfra::Command::Solaris::Base::Service.
