### PR TITLE
call super at docker backend initialize

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -1,6 +1,8 @@
 module Specinfra::Backend
   class Docker < Exec
     def initialize
+      super
+
       begin
         require 'docker' unless defined?(::Docker)
       rescue LoadError


### PR DESCRIPTION
After this [commit](https://github.com/serverspec/specinfra/commit/8f80161879f0843cf5f0aa7e46b8c77a637f7d0e), Base class set ```@config``` in initialize process. 
Docker backend also has self initialize process and call  ```get_config``` method. So currently this method got ```undefined method `[]' for nil:NilClass (NoMethodError)``` error. Because ```@config``` is nil. So need to call ```super``` method.