### PR TITLE
Add error_on_missing_backend_type option.

### DIFF
--- a/lib/specinfra.rb
+++ b/lib/specinfra.rb
@@ -23,6 +23,10 @@ module Specinfra
     def backend
       type = Specinfra.configuration.backend
       if type.nil?
+        if Specinfra.configuration.error_on_missing_backend_type
+          raise "No backend type is specified."
+        end
+
         warn "No backend type is specified. Fall back to :exec type."
         type = :exec
       end


### PR DESCRIPTION
If this is true and backend is nil, an error will be raised.