### PR TITLE
Integrate selinux file label

### DIFF
--- a/lib/specinfra/command/linux/base/file.rb
+++ b/lib/specinfra/command/linux/base/file.rb
@@ -12,7 +12,7 @@ class Specinfra::Command::Linux::Base::File < Specinfra::Command::Base::File
       "lsattr -d #{escape(file)} 2>&1 | awk '$1~/^-*#{escape(attribute)}-*$/ {exit 0} {exit 1}'"
     end
 
-    def get_selinux_label(file)
+    def get_selinuxlabel(file)
       "stat -c %C #{escape(file)}"
     end
   end

--- a/lib/specinfra/command/linux/base/file.rb
+++ b/lib/specinfra/command/linux/base/file.rb
@@ -11,5 +11,9 @@ class Specinfra::Command::Linux::Base::File < Specinfra::Command::Base::File
     def check_attribute(file, attribute)
       "lsattr -d #{escape(file)} 2>&1 | awk '$1~/^-*#{escape(attribute)}-*$/ {exit 0} {exit 1}'"
     end
+
+    def get_selinux_label(file)
+      "stat -c %C #{escape(file)}"
+    end
   end
 end

--- a/spec/command/linux/file_spec.rb
+++ b/spec/command/linux/file_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'linux'
+
+describe get_command(:get_file_selinuxlabel, 'some_file') do
+  it { should eq 'stat -c %C some_file' }
+end


### PR DESCRIPTION
add method and test case to retrieve the selinux security context/label from a file by stat, for i.e.

```
describe file('/usr/bin/docker') do
  its(:selinux_label) { should match /docker_exec_t/ }
end
```