### PR TITLE
Introduce specinfra/core

### DIFF
--- a/lib/specinfra.rb
+++ b/lib/specinfra.rb
@@ -1,21 +1,9 @@
-require 'specinfra/version'
-require 'specinfra/helper'
-require 'specinfra/backend'
-require 'specinfra/command'
-require 'specinfra/command_factory'
-require 'specinfra/command_result'
-require 'specinfra/configuration'
-require 'specinfra/runner'
-require 'specinfra/processor'
+require 'specinfra/core'
 
 include Specinfra
 
 module Specinfra
   class << self
-    def configuration
-      Specinfra::Configuration
-    end
-
     def command
       Specinfra::CommandFactory.instance
     end
@@ -50,30 +38,5 @@ if defined?(RSpec)
       example = RSpec.respond_to?(:current_example) ? RSpec.current_example : self.example
       Specinfra.backend.set_example(example)
     end
-  end
-end
-
-class Class
-  def subclasses
-    result = []
-    ObjectSpace.each_object(Class) do |k|
-      result << k if k < self
-    end
-    result
-  end
-end
-
-class String
-  def to_snake_case
-    self.gsub(/::/, '/').
-    gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-    gsub(/([a-z\d])([A-Z])/,'\1_\2').
-    tr("-", "_").
-    downcase
-  end
-
-  def to_camel_case
-    return self if self !~ /_/ && self =~ /[A-Z]+.*/
-    split('_').map{|e| e.capitalize}.join
   end
 end

--- a/lib/specinfra/backend/base.rb
+++ b/lib/specinfra/backend/base.rb
@@ -1,45 +1,47 @@
 require 'singleton'
 require 'specinfra/command_result'
 
-module Specinfra::Backend
-  class Base
-    def self.instance
-      @instance ||= self.new
-    end
+module Specinfra
+  module Backend
+    class Base
+      def self.instance
+        @instance ||= self.new
+      end
 
-    def initialize(config = {})
-      @config = config
-    end
+      def initialize(config = {})
+        @config = config
+      end
 
-    def get_config(key)
-      @config[key] || Specinfra.configuration.send(key)
-    end
+      def get_config(key)
+        @config[key] || Specinfra.configuration.send(key)
+      end
 
-    def set_config(key, value)
-      @config[key] = value
-    end
+      def set_config(key, value)
+        @config[key] = value
+      end
 
-    def os_info
-      return @os_info if @os_info
+      def os_info
+        return @os_info if @os_info
 
-      Specinfra::Helper::DetectOs.subclasses.each do |klass|
-        if @os_info = klass.new(self).detect
-          @os_info[:arch] ||= self.run_command('uname -m').stdout.strip
-          return @os_info
+        Specinfra::Helper::DetectOs.subclasses.each do |klass|
+          if @os_info = klass.new(self).detect
+            @os_info[:arch] ||= self.run_command('uname -m').stdout.strip
+            return @os_info
+          end
         end
       end
-    end
 
-    def command
-      CommandFactory.new(os_info)
-    end
+      def command
+        CommandFactory.new(os_info)
+      end
 
-    def host_inventory
-      @inventory ||= HostInventory.new(self)
-    end
+      def host_inventory
+        @inventory ||= HostInventory.new(self)
+      end
 
-    def set_example(e)
-      @example = e
+      def set_example(e)
+        @example = e
+      end
     end
   end
 end

--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -1,109 +1,111 @@
-module Specinfra::Backend
-  class Docker < Exec
-    def initialize(config = {})
-      super
+module Specinfra
+  module Backend
+    class Docker < Exec
+      def initialize(config = {})
+        super
 
-      begin
-        require 'docker' unless defined?(::Docker)
-      rescue LoadError
-        fail "Docker client library is not available. Try installing `docker-api' gem."
+        begin
+          require 'docker' unless defined?(::Docker)
+        rescue LoadError
+          fail "Docker client library is not available. Try installing `docker-api' gem."
+        end
+
+        ::Docker.url = get_config(:docker_url)
+
+        if image = get_config(:docker_image)
+          @images = []
+          @base_image = get_or_pull_image(image)
+
+          create_and_start_container
+          ObjectSpace.define_finalizer(self, proc { cleanup_container })
+        elsif container = get_config(:docker_container)
+          @container = ::Docker::Container.get(container)
+        else
+          fail 'Please specify docker_image or docker_container.'
+        end
       end
 
-      ::Docker.url = get_config(:docker_url)
+      def run_command(cmd, opts={})
+        cmd = build_command(cmd)
+        cmd = add_pre_command(cmd)
+        docker_run!(cmd)
+      end
 
-      if image = get_config(:docker_image)
-        @images = []
-        @base_image = get_or_pull_image(image)
+      def build_command(cmd)
+        cmd
+      end
 
+      def add_pre_command(cmd)
+        cmd
+      end
+
+      def send_file(from, to)
+        if @base_image.nil?
+          fail 'Cannot call send_file without docker_image.'
+        end
+
+        @images << current_image.insert_local('localPath' => from, 'outputPath' => to)
+        cleanup_container
         create_and_start_container
-        ObjectSpace.define_finalizer(self, proc { cleanup_container })
-      elsif container = get_config(:docker_container)
-        @container = ::Docker::Container.get(container)
-      else
-        fail 'Please specify docker_image or docker_container.'
-      end
-    end
-
-    def run_command(cmd, opts={})
-      cmd = build_command(cmd)
-      cmd = add_pre_command(cmd)
-      docker_run!(cmd)
-    end
-
-    def build_command(cmd)
-      cmd
-    end
-
-    def add_pre_command(cmd)
-      cmd
-    end
-
-    def send_file(from, to)
-      if @base_image.nil?
-        fail 'Cannot call send_file without docker_image.'
       end
 
-      @images << current_image.insert_local('localPath' => from, 'outputPath' => to)
-      cleanup_container
-      create_and_start_container
-    end
-
-    def commit_container
-      @container.commit
-    end
-
-    private
-
-    def create_and_start_container
-      opts = { 'Image' => current_image.id }
-
-      if current_image.json["Config"]["Cmd"].nil?
-        opts.merge!({'Cmd' => ['/bin/sh']})
+      def commit_container
+        @container.commit
       end
 
-      opts.merge!({'OpenStdin' => true})
+      private
 
-      if path = get_config(:path)
-        (opts['Env'] ||= []) << "PATH=#{path}"
+      def create_and_start_container
+        opts = { 'Image' => current_image.id }
+
+        if current_image.json["Config"]["Cmd"].nil?
+          opts.merge!({'Cmd' => ['/bin/sh']})
+        end
+
+        opts.merge!({'OpenStdin' => true})
+
+        if path = get_config(:path)
+          (opts['Env'] ||= []) << "PATH=#{path}"
+        end
+
+        env = get_config(:env).to_a.map { |v| v.join('=') }
+        opts['Env'] = opts['Env'].to_a.concat(env)
+
+        opts.merge!(get_config(:docker_container_create_options) || {})
+
+        @container = ::Docker::Container.create(opts)
+        @container.start
       end
 
-      env = get_config(:env).to_a.map { |v| v.join('=') }
-      opts['Env'] = opts['Env'].to_a.concat(env)
+      def cleanup_container
+        @container.stop
+        @container.delete
+      end
 
-      opts.merge!(get_config(:docker_container_create_options) || {})
+      def current_image
+        @images.last || @base_image
+      end
 
-      @container = ::Docker::Container.create(opts)
-      @container.start
-    end
+      def docker_run!(cmd, opts={})
+        stdout, stderr, status = @container.exec(['/bin/sh', '-c', cmd])
 
-    def cleanup_container
-      @container.stop
-      @container.delete
-    end
+        CommandResult.new :stdout => stdout.join, :stderr => stderr.join,
+        :exit_status => status
+      rescue ::Docker::Error::DockerError => e
+        raise
+      rescue => e
+        @container.kill
+        err = stderr.nil? ? ([e.message] + e.backtrace) : stderr
+        CommandResult.new :stdout => [stdout].join, :stderr => err.join,
+        :exit_status => (status || 1)
+      end
 
-    def current_image
-      @images.last || @base_image
-    end
-
-    def docker_run!(cmd, opts={})
-      stdout, stderr, status = @container.exec(['/bin/sh', '-c', cmd])
-
-      CommandResult.new :stdout => stdout.join, :stderr => stderr.join,
-      :exit_status => status
-    rescue ::Docker::Error::DockerError => e
-      raise
-    rescue => e
-      @container.kill
-      err = stderr.nil? ? ([e.message] + e.backtrace) : stderr
-      CommandResult.new :stdout => [stdout].join, :stderr => err.join,
-      :exit_status => (status || 1)
-    end
-
-    def get_or_pull_image(name)
-      begin
-        ::Docker::Image.get(name)
-      rescue ::Docker::Error::NotFoundError
-        ::Docker::Image.create('fromImage' => name)
+      def get_or_pull_image(name)
+        begin
+          ::Docker::Image.get(name)
+        rescue ::Docker::Error::NotFoundError
+          ::Docker::Image.create('fromImage' => name)
+        end
       end
     end
   end

--- a/lib/specinfra/backend/dockerfile.rb
+++ b/lib/specinfra/backend/dockerfile.rb
@@ -1,31 +1,32 @@
-# -*- coding: utf-8 -*-
-module Specinfra::Backend
-  class Dockerfile < Specinfra::Backend::Base
-    def initialize(config = {})
-      super
+module Specinfra
+  module Backend
+    class Dockerfile < Specinfra::Backend::Base
+      def initialize(config = {})
+        super
 
-      @lines = []
-      ObjectSpace.define_finalizer(self) {
-        if get_config(:dockerfile_finalizer).nil?
-          puts @lines
-        else
-          get_config(:dockerfile_finalizer).call(@lines)
-        end
-      }
-    end
+        @lines = []
+        ObjectSpace.define_finalizer(self) {
+          if get_config(:dockerfile_finalizer).nil?
+            puts @lines
+          else
+            get_config(:dockerfile_finalizer).call(@lines)
+          end
+        }
+      end
 
-    def run_command(cmd, opts={})
-      @lines << "RUN #{cmd}"
-      CommandResult.new
-    end
+      def run_command(cmd, opts={})
+        @lines << "RUN #{cmd}"
+        CommandResult.new
+      end
 
-    def send_file(from, to)
-      @lines << "ADD #{from} #{to}"
-      CommandResult.new
-    end
+      def send_file(from, to)
+        @lines << "ADD #{from} #{to}"
+        CommandResult.new
+      end
 
-    def from(base)
-      @lines << "FROM #{base}"
+      def from(base)
+        @lines << "FROM #{base}"
+      end
     end
   end
 end

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -2,77 +2,79 @@ require 'singleton'
 require 'fileutils'
 require 'shellwords'
 
-module Specinfra::Backend
-  class Exec < Base
-    def run_command(cmd, opts={})
-      cmd = build_command(cmd)
-      cmd = add_pre_command(cmd)
-      stdout = with_env do
-        `#{build_command(cmd)} 2>&1`
-      end
-      # In ruby 1.9, it is possible to use Open3.capture3, but not in 1.8
-      # stdout, stderr, status = Open3.capture3(cmd)
+module Specinfra
+  module Backend
+    class Exec < Base
+      def run_command(cmd, opts={})
+        cmd = build_command(cmd)
+        cmd = add_pre_command(cmd)
+        stdout = with_env do
+          `#{build_command(cmd)} 2>&1`
+        end
+        # In ruby 1.9, it is possible to use Open3.capture3, but not in 1.8
+        # stdout, stderr, status = Open3.capture3(cmd)
 
-      if @example
-        @example.metadata[:command] = cmd
-        @example.metadata[:stdout]  = stdout
-      end
+        if @example
+          @example.metadata[:command] = cmd
+          @example.metadata[:stdout]  = stdout
+        end
 
-      CommandResult.new :stdout => stdout, :exit_status => $?.exitstatus
-    end
-
-    def send_file(from, to)
-      FileUtils.cp(from, to)
-    end
-
-    def send_directory(from, to)
-      FileUtils.cp_r(from, to)
-    end
-
-    def build_command(cmd)
-      shell = get_config(:shell) || '/bin/sh'
-      cmd = cmd.shelljoin if cmd.is_a?(Array)
-      cmd = "#{shell.shellescape} -c #{cmd.to_s.shellescape}"
-
-      path = get_config(:path)
-      if path
-        cmd = %Q{env PATH="#{path}" #{cmd}}
+        CommandResult.new :stdout => stdout, :exit_status => $?.exitstatus
       end
 
-      cmd
-    end
-
-    private
-    def with_env
-      keys = %w[BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE
-          RUBYOPT GEM_HOME GEM_PATH GEM_CACHE]
-
-      keys.each { |key| ENV["_SPECINFRA_#{key}"] = ENV[key] ; ENV.delete(key) }
-
-      env = get_config(:env) || {}
-      env[:LANG] ||= 'C'
-
-      env.each do |key, value|
-        key = key.to_s
-        ENV["_SPECINFRA_#{key}"] = ENV[key];
-        ENV[key] = value
+      def send_file(from, to)
+        FileUtils.cp(from, to)
       end
 
-      yield
-    ensure
-      keys.each { |key| ENV[key] = ENV.delete("_SPECINFRA_#{key}") }
-      env.each do |key, value|
-        key = key.to_s
-        ENV[key] = ENV.delete("_SPECINFRA_#{key}");
+      def send_directory(from, to)
+        FileUtils.cp_r(from, to)
       end
-    end
 
-    def add_pre_command(cmd)
-      if get_config(:pre_command)
-        pre_cmd = build_command(get_config(:pre_command))
-        "#{pre_cmd} && #{cmd}"
-      else
+      def build_command(cmd)
+        shell = get_config(:shell) || '/bin/sh'
+        cmd = cmd.shelljoin if cmd.is_a?(Array)
+        cmd = "#{shell.shellescape} -c #{cmd.to_s.shellescape}"
+
+        path = get_config(:path)
+        if path
+          cmd = %Q{env PATH="#{path}" #{cmd}}
+        end
+
         cmd
+      end
+
+      private
+      def with_env
+        keys = %w[BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE
+            RUBYOPT GEM_HOME GEM_PATH GEM_CACHE]
+
+        keys.each { |key| ENV["_SPECINFRA_#{key}"] = ENV[key] ; ENV.delete(key) }
+
+        env = get_config(:env) || {}
+        env[:LANG] ||= 'C'
+
+        env.each do |key, value|
+          key = key.to_s
+          ENV["_SPECINFRA_#{key}"] = ENV[key];
+          ENV[key] = value
+        end
+
+        yield
+      ensure
+        keys.each { |key| ENV[key] = ENV.delete("_SPECINFRA_#{key}") }
+        env.each do |key, value|
+          key = key.to_s
+          ENV[key] = ENV.delete("_SPECINFRA_#{key}");
+        end
+      end
+
+      def add_pre_command(cmd)
+        if get_config(:pre_command)
+          pre_cmd = build_command(get_config(:pre_command))
+          "#{pre_cmd} && #{cmd}"
+        else
+          cmd
+        end
       end
     end
   end

--- a/lib/specinfra/backend/lxc.rb
+++ b/lib/specinfra/backend/lxc.rb
@@ -1,43 +1,45 @@
-module Specinfra::Backend
-  class Lxc < Exec
-    def initialize(config = {})
-      super
+module Specinfra
+  module Backend
+    class Lxc < Exec
+      def initialize(config = {})
+        super
 
-      begin
-        require 'lxc/extra' unless defined?(::LXC::Extra)
-      rescue LoadError
-        fail "LXC client library is not available. Try installing `lxc-extra' gem"
+        begin
+          require 'lxc/extra' unless defined?(::LXC::Extra)
+        rescue LoadError
+          fail "LXC client library is not available. Try installing `lxc-extra' gem"
+        end
       end
-    end
 
-    def run_command(cmd, opts={})
-      cmd = build_command(cmd)
-      cmd = add_pre_command(cmd)
-      out, ret = ct.execute do
-        out = `#{cmd}  2>&1`
-        [out, $?.dup]
+      def run_command(cmd, opts={})
+        cmd = build_command(cmd)
+        cmd = add_pre_command(cmd)
+        out, ret = ct.execute do
+          out = `#{cmd}  2>&1`
+          [out, $?.dup]
+        end
+        if @example
+          @example.metadata[:command] = cmd
+          @example.metadata[:stdout]  = out
+        end
+        CommandResult.new :stdout => out, :exit_status => ret.exitstatus
       end
-      if @example
-        @example.metadata[:command] = cmd
-        @example.metadata[:stdout]  = out
+
+      def build_command(cmd)
+        cmd
       end
-      CommandResult.new :stdout => out, :exit_status => ret.exitstatus
-    end
 
-    def build_command(cmd)
-      cmd
-    end
+      def add_pre_command(cmd)
+        cmd
+      end
 
-    def add_pre_command(cmd)
-      cmd
-    end
+      def send_file(from, to)
+        FileUtils.cp(from, File.join(ct.config_item('lxc.rootfs'), to))
+      end
 
-    def send_file(from, to)
-      FileUtils.cp(from, File.join(ct.config_item('lxc.rootfs'), to))
-    end
-
-    def ct
-      @ct ||= ::LXC::Container.new(get_config(:lxc))
+      def ct
+        @ct ||= ::LXC::Container.new(get_config(:lxc))
+      end
     end
   end
 end

--- a/lib/specinfra/backend/shell_script.rb
+++ b/lib/specinfra/backend/shell_script.rb
@@ -1,26 +1,28 @@
 require 'singleton'
 
-module Specinfra::Backend
-  class ShellScript < Base
-    def initialize(config = {})
-      super
+module Specinfra
+  module Backend
+    class ShellScript < Base
+      def initialize(config = {})
+        super
 
-      @lines = [ "#!/bin/sh", "" ]
-      ObjectSpace.define_finalizer(self, Writer.new(@lines))
-    end
-
-    def run_command(cmd, opts={})
-      @lines << cmd
-      CommandResult.new
-    end
-
-    class Writer
-      def initialize(lines)
-        @lines = lines
+        @lines = [ "#!/bin/sh", "" ]
+        ObjectSpace.define_finalizer(self, Writer.new(@lines))
       end
 
-      def call(*args)
-        puts @lines
+      def run_command(cmd, opts={})
+        @lines << cmd
+        CommandResult.new
+      end
+
+      class Writer
+        def initialize(lines)
+          @lines = lines
+        end
+
+        def call(*args)
+          puts @lines
+        end
       end
     end
   end

--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -3,171 +3,173 @@ require 'specinfra/backend/exec'
 require 'net/ssh'
 require 'net/scp'
 
-module Specinfra::Backend
-  class Ssh < Exec
-    def run_command(cmd, opt={})
-      cmd = build_command(cmd)
-      cmd = add_pre_command(cmd)
-      ret = with_env do
-        ssh_exec!(cmd)
-      end
-
-      ret[:stdout].gsub!(/\r\n/, "\n")
-      ret[:stdout].gsub!(/\A\n/, "") if sudo?
-
-      if @example
-        @example.metadata[:command] = cmd
-        @example.metadata[:stdout]  = ret[:stdout]
-      end
-
-      CommandResult.new ret
-    end
-
-    def send_file(from, to)
-      scp_upload!(from, to)
-    end
-
-    def send_directory(from, to)
-      scp_upload!(from, to, :recursive => true)
-    end
-
-    def build_command(cmd)
-      cmd = super(cmd)
-      if sudo?
-        cmd = "#{sudo} -p '#{prompt}' #{cmd}"
-      end
-      cmd
-    end
-
-    private
-    def prompt
-      'Password: '
-    end
-
-    def with_env
-      env = get_config(:env) || {}
-      env[:LANG] ||= 'C'
-
-      ssh_options = get_config(:ssh_options) || {}
-      ssh_options[:send_env] ||= []
-
-      env.each do |key, value|
-        key = key.to_s
-        ENV["_SPECINFRA_#{key}"] = ENV[key];
-        ENV[key] = value
-        ssh_options[:send_env] << key
-      end
-
-      yield
-    ensure
-      env.each do |key, value|
-        key = key.to_s
-        ENV[key] = ENV.delete("_SPECINFRA_#{key}");
-      end
-    end
-
-    def create_ssh
-      Net::SSH.start(
-        get_config(:host),
-        get_config(:ssh_options)[:user],
-        get_config(:ssh_options)
-      )
-    end
-
-    def create_scp
-      ssh = get_config(:ssh)
-      if ssh.nil?
-        ssh = create_ssh
-      end
-      Net::SCP.new(ssh)
-    end
-
-    def scp_upload!(from, to, opt={})
-      if get_config(:scp).nil?
-        set_config(:scp, create_scp)
-      end
-
-      tmp = File.join('/tmp', File.basename(to))
-      scp = get_config(:scp)
-      scp.upload!(from, tmp, opt)
-      run_command(command.get(:move_file, tmp, to))
-    end
-
-    def ssh_exec!(command)
-      stdout_data = ''
-      stderr_data = ''
-      exit_status = nil
-      exit_signal = nil
-      retry_prompt = /^Sorry, try again/
-
-      if get_config(:ssh).nil?
-        set_config(:ssh, create_ssh)
-      end
-
-      ssh = get_config(:ssh)
-      ssh.open_channel do |channel|
-        if get_config(:sudo_password) or get_config(:request_pty)
-          channel.request_pty do |ch, success|
-            abort "Could not obtain pty " if !success
-          end
+module Specinfra
+  module Backend
+    class Ssh < Exec
+      def run_command(cmd, opt={})
+        cmd = build_command(cmd)
+        cmd = add_pre_command(cmd)
+        ret = with_env do
+          ssh_exec!(cmd)
         end
-        channel.exec("#{command}") do |ch, success|
-          abort "FAILED: couldn't execute command (ssh.channel.exec)" if !success
-          channel.on_data do |ch, data|
-            if data.match retry_prompt
-              abort 'Wrong sudo password! Please confirm your password.'
-            elsif data.match /^#{prompt}/
-              channel.send_data "#{get_config(:sudo_password)}\n"
-            else
-              stdout_data += data
-            end
-          end
 
-          channel.on_extended_data do |ch, type, data|
-            if data.match /you must have a tty to run sudo/
-              abort 'Please write "set :request_pty, true" in your spec_helper.rb or other appropriate file.'
-            end
+        ret[:stdout].gsub!(/\r\n/, "\n")
+        ret[:stdout].gsub!(/\A\n/, "") if sudo?
 
-            if data.match /^sudo: no tty present and no askpass program specified/
-              abort 'Please set sudo password to Specinfra.configuration.sudo_password.'
-            else
-              stderr_data += data
-            end
-          end
+        if @example
+          @example.metadata[:command] = cmd
+          @example.metadata[:stdout]  = ret[:stdout]
+        end
 
-          channel.on_request("exit-status") do |ch, data|
-            exit_status = data.read_long
-          end
+        CommandResult.new ret
+      end
 
-          channel.on_request("exit-signal") do |ch, data|
-            exit_signal = data.read_long
-          end
+      def send_file(from, to)
+        scp_upload!(from, to)
+      end
+
+      def send_directory(from, to)
+        scp_upload!(from, to, :recursive => true)
+      end
+
+      def build_command(cmd)
+        cmd = super(cmd)
+        if sudo?
+          cmd = "#{sudo} -p '#{prompt}' #{cmd}"
+        end
+        cmd
+      end
+
+      private
+      def prompt
+        'Password: '
+      end
+
+      def with_env
+        env = get_config(:env) || {}
+        env[:LANG] ||= 'C'
+
+        ssh_options = get_config(:ssh_options) || {}
+        ssh_options[:send_env] ||= []
+
+        env.each do |key, value|
+          key = key.to_s
+          ENV["_SPECINFRA_#{key}"] = ENV[key];
+          ENV[key] = value
+          ssh_options[:send_env] << key
+        end
+
+        yield
+      ensure
+        env.each do |key, value|
+          key = key.to_s
+          ENV[key] = ENV.delete("_SPECINFRA_#{key}");
         end
       end
-      ssh.loop
-      { :stdout => stdout_data, :stderr => stderr_data, :exit_status => exit_status, :exit_signal => exit_signal }
-    end
 
-    def sudo
-      if sudo_path = get_config(:sudo_path)
-        sudo_path += '/sudo'
-      else
-        sudo_path = 'sudo'
+      def create_ssh
+        Net::SSH.start(
+          get_config(:host),
+          get_config(:ssh_options)[:user],
+          get_config(:ssh_options)
+        )
       end
 
-      sudo_options = get_config(:sudo_options)
-      if sudo_options
-        sudo_options = sudo_options.shelljoin if sudo_options.is_a?(Array)
-        sudo_options = ' ' + sudo_options
+      def create_scp
+        ssh = get_config(:ssh)
+        if ssh.nil?
+          ssh = create_ssh
+        end
+        Net::SCP.new(ssh)
       end
 
-      "#{sudo_path.shellescape}#{sudo_options}"
-    end
+      def scp_upload!(from, to, opt={})
+        if get_config(:scp).nil?
+          set_config(:scp, create_scp)
+        end
 
-    def sudo?
-      user = get_config(:ssh_options)[:user]
-      disable_sudo = get_config(:disable_sudo)
-      user != 'root' && !disable_sudo
+        tmp = File.join('/tmp', File.basename(to))
+        scp = get_config(:scp)
+        scp.upload!(from, tmp, opt)
+        run_command(command.get(:move_file, tmp, to))
+      end
+
+      def ssh_exec!(command)
+        stdout_data = ''
+        stderr_data = ''
+        exit_status = nil
+        exit_signal = nil
+        retry_prompt = /^Sorry, try again/
+
+        if get_config(:ssh).nil?
+          set_config(:ssh, create_ssh)
+        end
+
+        ssh = get_config(:ssh)
+        ssh.open_channel do |channel|
+          if get_config(:sudo_password) or get_config(:request_pty)
+            channel.request_pty do |ch, success|
+              abort "Could not obtain pty " if !success
+            end
+          end
+          channel.exec("#{command}") do |ch, success|
+            abort "FAILED: couldn't execute command (ssh.channel.exec)" if !success
+            channel.on_data do |ch, data|
+              if data.match retry_prompt
+                abort 'Wrong sudo password! Please confirm your password.'
+              elsif data.match /^#{prompt}/
+                channel.send_data "#{get_config(:sudo_password)}\n"
+              else
+                stdout_data += data
+              end
+            end
+
+            channel.on_extended_data do |ch, type, data|
+              if data.match /you must have a tty to run sudo/
+                abort 'Please write "set :request_pty, true" in your spec_helper.rb or other appropriate file.'
+              end
+
+              if data.match /^sudo: no tty present and no askpass program specified/
+                abort 'Please set sudo password to Specinfra.configuration.sudo_password.'
+              else
+                stderr_data += data
+              end
+            end
+
+            channel.on_request("exit-status") do |ch, data|
+              exit_status = data.read_long
+            end
+
+            channel.on_request("exit-signal") do |ch, data|
+              exit_signal = data.read_long
+            end
+          end
+        end
+        ssh.loop
+        { :stdout => stdout_data, :stderr => stderr_data, :exit_status => exit_status, :exit_signal => exit_signal }
+      end
+
+      def sudo
+        if sudo_path = get_config(:sudo_path)
+          sudo_path += '/sudo'
+        else
+          sudo_path = 'sudo'
+        end
+
+        sudo_options = get_config(:sudo_options)
+        if sudo_options
+          sudo_options = sudo_options.shelljoin if sudo_options.is_a?(Array)
+          sudo_options = ' ' + sudo_options
+        end
+
+        "#{sudo_path.shellescape}#{sudo_options}"
+      end
+
+      def sudo?
+        user = get_config(:ssh_options)[:user]
+        disable_sudo = get_config(:disable_sudo)
+        user != 'root' && !disable_sudo
+      end
     end
   end
 end

--- a/lib/specinfra/backend/telnet.rb
+++ b/lib/specinfra/backend/telnet.rb
@@ -2,108 +2,110 @@
 require 'specinfra/backend/exec'
 require 'net/telnet'
 
-module Specinfra::Backend
-  class Telnet < Exec
-    def run_command(cmd, opt={})
-      cmd = build_command(cmd)
-      cmd = add_pre_command(cmd)
-      ret = with_env do
-        telnet_exec!(cmd)
-      end
-      if @example
-        @example.metadata[:command] = cmd
-        @example.metadata[:stdout]  = ret[:stdout]
-      end
+module Specinfra
+  module Backend
+    class Telnet < Exec
+      def run_command(cmd, opt={})
+        cmd = build_command(cmd)
+        cmd = add_pre_command(cmd)
+        ret = with_env do
+          telnet_exec!(cmd)
+        end
+        if @example
+          @example.metadata[:command] = cmd
+          @example.metadata[:stdout]  = ret[:stdout]
+        end
 
-      CommandResult.new ret
-    end
-
-    def build_command(cmd)
-      cmd = super(cmd)
-      cmd
-    end
-
-    private
-    def prompt
-      'Login: '
-    end
-
-    def with_env
-      env = get_config(:env) || {}
-      env[:LANG] ||= 'C'
-
-      env.each do |key, value|
-        key = key.to_s
-        ENV["_SPECINFRA_#{key}"] = ENV[key];
-        ENV[key] = value
+        CommandResult.new ret
       end
 
-      yield
-    ensure
-      env.each do |key, value|
-        key = key.to_s
-        ENV[key] = ENV.delete("_SPECINFRA_#{key}");
-      end
-    end
-
-    def add_pre_command(cmd)
-      if get_config(:pre_command)
-        pre_cmd = build_command(get_config(:pre_command))
-        "#{pre_cmd} && #{cmd}"
-      else
+      def build_command(cmd)
+        cmd = super(cmd)
         cmd
       end
-    end
 
-    def telnet_exec!( command )
-      stdout_data = ''
-      stderr_data = ''
-      exit_status = nil
-      exit_signal = nil
-      retry_prompt = /^Login: /
-      if get_config(:telnet).nil?
-        set_config(:telnet, create_telnet)
-      end
-      telnet = get_config(:telnet)
-      re = [] 
-      unless telnet.nil?
-        re = telnet.cmd( "#{command}; echo $?" ).split("\n")[0..-2]
-        exit_status = re.last.to_i
-        stdout_data = re[1..-2].join("\n")
-      end
-      { :stdout => stdout_data, :stderr => stderr_data, :exit_status => exit_status, :exit_signal => exit_signal }
-    end
- 
-    def create_telnet
-      tel = Net::Telnet.new( "Host" => get_config(:host) )
-      tel.login( 
-        "Name" => get_config(:telnet_options)[:user], 
-        "Password" => get_config(:telnet_options)[:pass]
-      )
-      tel
-    rescue
-      return nil
-    end
-
-    def sudo
-      if sudo_path = get_config(:sudo_path)
-        sudo_path += '/sudo'
-      else
-        sudo_path = 'sudo'
+      private
+      def prompt
+        'Login: '
       end
 
-      sudo_options = get_config(:sudo_options)
-      if sudo_options
-        sudo_options = sudo_options.shelljoin if sudo_options.is_a?(Array)
-        sudo_options = ' ' + sudo_options
+      def with_env
+        env = get_config(:env) || {}
+        env[:LANG] ||= 'C'
+
+        env.each do |key, value|
+          key = key.to_s
+          ENV["_SPECINFRA_#{key}"] = ENV[key];
+          ENV[key] = value
+        end
+
+        yield
+      ensure
+        env.each do |key, value|
+          key = key.to_s
+          ENV[key] = ENV.delete("_SPECINFRA_#{key}");
+        end
       end
 
-      "#{sudo_path.shellescape}#{sudo_options}"
-    end
+      def add_pre_command(cmd)
+        if get_config(:pre_command)
+          pre_cmd = build_command(get_config(:pre_command))
+          "#{pre_cmd} && #{cmd}"
+        else
+          cmd
+        end
+      end
 
-    def sudo?
-      false
-    end
+      def telnet_exec!( command )
+        stdout_data = ''
+        stderr_data = ''
+        exit_status = nil
+        exit_signal = nil
+        retry_prompt = /^Login: /
+        if get_config(:telnet).nil?
+          set_config(:telnet, create_telnet)
+        end
+        telnet = get_config(:telnet)
+        re = [] 
+        unless telnet.nil?
+          re = telnet.cmd( "#{command}; echo $?" ).split("\n")[0..-2]
+          exit_status = re.last.to_i
+          stdout_data = re[1..-2].join("\n")
+        end
+        { :stdout => stdout_data, :stderr => stderr_data, :exit_status => exit_status, :exit_signal => exit_signal }
+      end
+   
+      def create_telnet
+        tel = Net::Telnet.new( "Host" => get_config(:host) )
+        tel.login( 
+          "Name" => get_config(:telnet_options)[:user], 
+          "Password" => get_config(:telnet_options)[:pass]
+        )
+        tel
+      rescue
+        return nil
+      end
 
+      def sudo
+        if sudo_path = get_config(:sudo_path)
+          sudo_path += '/sudo'
+        else
+          sudo_path = 'sudo'
+        end
+
+        sudo_options = get_config(:sudo_options)
+        if sudo_options
+          sudo_options = sudo_options.shelljoin if sudo_options.is_a?(Array)
+          sudo_options = ' ' + sudo_options
+        end
+
+        "#{sudo_path.shellescape}#{sudo_options}"
+      end
+
+      def sudo?
+        false
+      end
+
+    end
   end
 end

--- a/lib/specinfra/backend/winrm.rb
+++ b/lib/specinfra/backend/winrm.rb
@@ -1,24 +1,26 @@
-module Specinfra::Backend
-  class Winrm < Base
-    include PowerShell::ScriptHelper
+module Specinfra
+  module Backend
+    class Winrm < Base
+      include PowerShell::ScriptHelper
 
-    def run_command(cmd, opts={})
-      set_config(:os, {:family => 'windows'})
-      script = create_script(cmd)
-      winrm = get_config(:winrm)
+      def run_command(cmd, opts={})
+        set_config(:os, {:family => 'windows'})
+        script = create_script(cmd)
+        winrm = get_config(:winrm)
 
-      result = winrm.powershell(script)
-      stdout, stderr = [:stdout, :stderr].map do |s|
-        result[:data].select {|item| item.key? s}.map {|item| item[s]}.join
+        result = winrm.powershell(script)
+        stdout, stderr = [:stdout, :stderr].map do |s|
+          result[:data].select {|item| item.key? s}.map {|item| item[s]}.join
+        end
+        result[:exitcode] = 1 if result[:exitcode] == 0 and !stderr.empty?
+
+        if @example
+          @example.metadata[:command] = script
+          @example.metadata[:stdout]  = stdout + stderr
+        end
+
+        CommandResult.new :stdout => stdout, :stderr => stderr, :exit_status => result[:exitcode]
       end
-      result[:exitcode] = 1 if result[:exitcode] == 0 and !stderr.empty?
-
-      if @example
-        @example.metadata[:command] = script
-        @example.metadata[:stdout]  = stdout + stderr
-      end
-
-      CommandResult.new :stdout => stdout, :stderr => stderr, :exit_status => result[:exitcode]
     end
   end
 end

--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -1,4 +1,7 @@
-module Specinfra::Command; end
+module Specinfra
+  module Command
+  end
+end
 
 # Module
 require 'specinfra/command/module'

--- a/lib/specinfra/command/module.rb
+++ b/lib/specinfra/command/module.rb
@@ -1,2 +1,7 @@
-module  Specinfra::Command::Module; end
+module Specinfra
+  module Command
+    module Module
+    end
+  end
+end
 

--- a/lib/specinfra/command/module/systemd.rb
+++ b/lib/specinfra/command/module/systemd.rb
@@ -1,40 +1,47 @@
-module Specinfra::Command::Module::Systemd
-  def check_is_enabled(service, level="multi-user.target")
-    if level.to_s =~ /^\d+$/
-      level = "runlevel#{level}.target"
+module Specinfra
+  module Command
+    module Module
+      module Systemd
+        def check_is_enabled(service, level="multi-user.target")
+          if level.to_s =~ /^\d+$/
+            level = "runlevel#{level}.target"
+          end
+          unless service.include?('.')
+            service += '.service'
+          end
+
+          "systemctl --plain list-dependencies #{level} | grep '\\(^\\| \\)#{escape(service)}$'"
+        end
+
+        def check_is_running(service)
+          "systemctl is-active #{escape(service)}"
+        end
+
+        def enable(service)
+          "systemctl enable #{escape(service)}"
+        end
+
+        def disable(service)
+          "systemctl disable #{escape(service)}"
+        end
+
+        def start(service)
+          "systemctl start #{escape(service)}"
+        end
+
+        def stop(service)
+          "systemctl stop #{escape(service)}"
+        end
+
+        def restart(service)
+          "systemctl restart #{escape(service)}"
+        end
+
+        def reload(service)
+          "systemctl reload #{escape(service)}"
+        end
+      end
     end
-    unless service.include?('.')
-      service += '.service'
-    end
-
-    "systemctl --plain list-dependencies #{level} | grep '\\(^\\| \\)#{escape(service)}$'"
-  end
-
-  def check_is_running(service)
-    "systemctl is-active #{escape(service)}"
-  end
-
-  def enable(service)
-    "systemctl enable #{escape(service)}"
-  end
-
-  def disable(service)
-    "systemctl disable #{escape(service)}"
-  end
-
-  def start(service)
-    "systemctl start #{escape(service)}"
-  end
-
-  def stop(service)
-    "systemctl stop #{escape(service)}"
-  end
-
-  def restart(service)
-    "systemctl restart #{escape(service)}"
-  end
-
-  def reload(service)
-    "systemctl reload #{escape(service)}"
   end
 end
+

--- a/lib/specinfra/command/module/zfs.rb
+++ b/lib/specinfra/command/module/zfs.rb
@@ -1,18 +1,25 @@
-module Specinfra::Command::Module::Zfs
-  def check_exists(zfs)
-      "zfs list -H #{escape(zfs)}"
-  end
+module Specinfra
+  module Command
+    module Module
+      module Zfs
+        def check_exists(zfs)
+            "zfs list -H #{escape(zfs)}"
+        end
 
-  def check_has_property(zfs, property=nil)
-    commands = []
-    property.sort.each do |key, value|
-      regexp = "^#{value}$"
-      commands << "zfs list -H -o #{escape(key)} #{escape(zfs)} | grep -- #{escape(regexp)}"
+        def check_has_property(zfs, property=nil)
+          commands = []
+          property.sort.each do |key, value|
+            regexp = "^#{value}$"
+            commands << "zfs list -H -o #{escape(key)} #{escape(zfs)} | grep -- #{escape(regexp)}"
+          end
+          commands.join(' && ')
+        end
+
+        def get_property(zfs)
+          "zfs get -Hp -o property,value all #{escape(zfs)}"
+        end
+      end
     end
-    commands.join(' && ')
-  end
-
-  def get_property(zfs)
-    "zfs get -Hp -o property,value all #{escape(zfs)}"
   end
 end
+

--- a/lib/specinfra/core.rb
+++ b/lib/specinfra/core.rb
@@ -1,0 +1,18 @@
+require 'specinfra/version'
+require 'specinfra/ext'
+require 'specinfra/helper'
+require 'specinfra/command'
+require 'specinfra/command_factory'
+require 'specinfra/command_result'
+require 'specinfra/backend'
+require 'specinfra/configuration'
+require 'specinfra/runner'
+require 'specinfra/processor'
+
+module Specinfra
+  class << self
+    def configuration
+      Specinfra::Configuration
+    end
+  end
+end

--- a/lib/specinfra/ext.rb
+++ b/lib/specinfra/ext.rb
@@ -1,0 +1,2 @@
+require 'specinfra/ext/class'
+require 'specinfra/ext/string'

--- a/lib/specinfra/ext/class.rb
+++ b/lib/specinfra/ext/class.rb
@@ -1,0 +1,9 @@
+class Class
+  def subclasses
+    result = []
+    ObjectSpace.each_object(Class) do |k|
+      result << k if k < self
+    end
+    result
+  end
+end

--- a/lib/specinfra/ext/string.rb
+++ b/lib/specinfra/ext/string.rb
@@ -1,0 +1,14 @@
+class String
+  def to_snake_case
+    self.gsub(/::/, '/').
+    gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
+    gsub(/([a-z\d])([A-Z])/,'\1_\2').
+    tr("-", "_").
+    downcase
+  end
+
+  def to_camel_case
+    return self if self !~ /_/ && self =~ /[A-Z]+.*/
+    split('_').map{|e| e.capitalize}.join
+  end
+end

--- a/lib/specinfra/helper/detect_os.rb
+++ b/lib/specinfra/helper/detect_os.rb
@@ -1,19 +1,21 @@
-module Specinfra::Helper
-  class DetectOs
-    def self.detect
-      self.new(Specinfra.backend).detect
-    end
+module Specinfra
+  module Helper
+    class DetectOs
+      def self.detect
+        self.new(Specinfra.backend).detect
+      end
 
-    def initialize(backend)
-      @backend = backend
-    end
+      def initialize(backend)
+        @backend = backend
+      end
 
-    def run_command(cmd)
-      @backend.run_command(cmd)
-    end
+      def run_command(cmd)
+        @backend.run_command(cmd)
+      end
 
-    def detect
-      raise NotImplementedError
+      def detect
+        raise NotImplementedError
+      end
     end
   end
 end

--- a/lib/specinfra/helper/os.rb
+++ b/lib/specinfra/helper/os.rb
@@ -1,23 +1,28 @@
 require 'specinfra/helper/detect_os'
 
-module Specinfra::Helper::Os
-  def os
-    property[:os] = {} if ! property[:os]
-    if ! property[:os].include?(:family)
-      property[:os] = detect_os
-    end
-    property[:os]
-  end
+module Specinfra
+  module Helper
+    module Os
+      def os
+        property[:os] = {} if ! property[:os]
+        if ! property[:os].include?(:family)
+          property[:os] = detect_os
+        end
+        property[:os]
+      end
 
-  private
-  def detect_os
-    return Specinfra.configuration.os if Specinfra.configuration.os
-    Specinfra::Helper::DetectOs.subclasses.each do |c|
-      res = c.detect
-      if res
-        res[:arch] ||= Specinfra.backend.run_command('uname -m').stdout.strip
-        return res
+      private
+      def detect_os
+        return Specinfra.configuration.os if Specinfra.configuration.os
+        Specinfra::Helper::DetectOs.subclasses.each do |c|
+          res = c.detect
+          if res
+            res[:arch] ||= Specinfra.backend.run_command('uname -m').stdout.strip
+            return res
+          end
+        end
       end
     end
   end
 end
+

--- a/lib/specinfra/helper/set.rb
+++ b/lib/specinfra/helper/set.rb
@@ -1,5 +1,10 @@
-module Specinfra::Helper::Set
-  def set(param, *value)
-    Specinfra.configuration.send(param, *value)
+module Specinfra
+  module Helper
+    module Set
+      def set(param, *value)
+        Specinfra.configuration.send(param, *value)
+      end
+    end
   end
 end
+


### PR DESCRIPTION
In order to avoid helper methods are defined, split core classes into specinfra/core.rb. ([This commit](https://github.com/serverspec/specinfra/commit/ca985a7469dc8eb836c66485d7e0d1349634d422))

Related to the above change, I changed `module M1::M2` to `module M1; module M2`. Because specinfra/core does not [`include Specinfra`](https://github.com/serverspec/specinfra/blob/6f7247c1d2402986a0be19e48069c059b692c2f2/lib/specinfra.rb#L3), NameError will be occured.
(I know this change makes blame-ability less...)

This PR keeps compatiblity from older version.