### PR TITLE
Add virtualization to host inventory

### DIFF
--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -10,6 +10,7 @@ module Specinfra
       platform_version
       filesystem
       cpu
+      virtualization
     }
 
     include Enumerable

--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -1,0 +1,13 @@
+module Specinfra
+  class HostInventory
+    class Virtualization < Base
+      def get
+        res = {}
+        if backend.run_command('ls /.dockerinit').success?
+          res[:system] = 'docker'
+        end
+        res
+      end
+    end
+  end
+end


### PR DESCRIPTION
You can get virtualization infomationlike this.

```ruby
node[:virtualization]
```

Currently supports only docker for `node[:virtualization][:system]` .