### PR TITLE
Fix service resource for CentOS 5.x

### DIFF
--- a/lib/specinfra/command/redhat/base/service.rb
+++ b/lib/specinfra/command/redhat/base/service.rb
@@ -1,15 +1,27 @@
 class Specinfra::Command::Redhat::Base::Service < Specinfra::Command::Linux::Base::Service
   class << self
+    # CentOS 5.x does not include /sbin in $PATH for non-root users.
+    def chkconfig_path ()
+      rh_rel_file = '/etc/redhat-release'
+      "chkconfig" unless File.exists? rh_rel_file
+      # Extra redundant File.exists? required otherwise spec tests fail.
+      if File.exists? rh_rel_file and IO.read(rh_rel_file).chomp.match(/^CentOS release 5\./)
+        "/sbin/chkconfig"
+      else
+        "chkconfig"
+      end
+    end
+
     def check_is_enabled(service, level=3)
-      "chkconfig --list #{escape(service)} | grep #{level}:on"
+      "#{chkconfig_path} --list #{escape(service)} | grep #{level}:on"
     end
 
     def enable(service)
-      "chkconfig #{escape(service)} on"
+      "#{chkconfig_path} #{escape(service)} on"
     end
 
     def disable(service)
-      "chkconfig #{escape(service)} off"
+      "#{chkconfig_path} #{escape(service)} off"
     end
 
     def start(service)


### PR DESCRIPTION
Missing /sbin in PATH by default and sudo not in use. Explicitly specifies chkconfig path in this scenario. Verified behaviour locally in test-kitchen and it worked.

I could not come up with a clean way to get spec tests working for this (as it depends on a file existing), and doing test-kitchen tests against specinfra for CentOS 5.x feels a bit Test-ception :) tests pass in their current state, just missing CentOS 5.x coverage specifically.