### PR TITLE
Use OpenBSD rc.d scripts for service checks.

### DIFF
--- a/lib/specinfra/command/openbsd/base/service.rb
+++ b/lib/specinfra/command/openbsd/base/service.rb
@@ -1,11 +1,11 @@
 class Specinfra::Command::Openbsd::Base::Service < Specinfra::Command::Base::Service
   class << self
     def check_is_enabled(service, level=nil)
-      "rcctl status #{escape(service)}"
+      "/etc/rc.d/#{escape(service)} status"
     end
 
     def check_is_running(service)
-      "rcctl check #{escape(service)}"
+      "/etc/rc.d/#{escape(service)} check"
     end
   end
 end


### PR DESCRIPTION
The current code uses `rcctl`, which is a utility that is included in
OpenBSD 5.7, which is not yet released.