### PR TITLE
Add arch to host inventory.

### DIFF
--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -11,7 +11,7 @@ module Specinfra
       filesystem
       cpu
       virtualization
-      arch
+      kernel
     }
 
     include Enumerable

--- a/lib/specinfra/host_inventory.rb
+++ b/lib/specinfra/host_inventory.rb
@@ -11,6 +11,7 @@ module Specinfra
       filesystem
       cpu
       virtualization
+      arch
     }
 
     include Enumerable

--- a/lib/specinfra/host_inventory/arch.rb
+++ b/lib/specinfra/host_inventory/arch.rb
@@ -1,9 +1,0 @@
-module Specinfra
-  class HostInventory
-    class Arch < Base
-      def get
-        backend.os_info[:arch]
-      end
-    end
-  end
-end

--- a/lib/specinfra/host_inventory/arch.rb
+++ b/lib/specinfra/host_inventory/arch.rb
@@ -1,0 +1,9 @@
+module Specinfra
+  class HostInventory
+    class Arch < Base
+      def get
+        backend.os_info[:arch]
+      end
+    end
+  end
+end

--- a/lib/specinfra/host_inventory/kernel.rb
+++ b/lib/specinfra/host_inventory/kernel.rb
@@ -1,0 +1,12 @@
+module Specinfra
+  class HostInventory
+    class Kernel < Base
+      def get
+        kernel = {}
+        kernel['machine'] = backend.os_info[:arch]
+
+        kernel
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add OS architecture information to `host_inventory` (is the same as `os[:arch]`).
You can get architecture infomation like this.

```
node[:arch]
```