### PR TITLE
Support non-verbose mode(*) and old metadata(!)

### DIFF
--- a/lib/specinfra/command/redhat/base/yumrepo.rb
+++ b/lib/specinfra/command/redhat/base/yumrepo.rb
@@ -5,7 +5,7 @@ class Specinfra::Command::Redhat::Base::Yumrepo < Specinfra::Command::Linux::Bas
     end
 
     def check_is_enabled(repository)
-      "yum repolist all -C | grep ^#{escape(repository)} | grep enabled"
+      "yum repolist enabled -C | grep -qs \"^[\\!\\*]\\?#{escape(repository)}\""
     end
   end
 end


### PR DESCRIPTION
This PR is support CentOS 7 and Amazon Linux >= 2014.03(yum repolist).

Example:

```
$ yum repolist enabled -C
Loaded plugins: fastestmirror, priorities, update-motd, upgrade-helper
62 packages excluded due to repository priority protections
repo id                                                          repo name                                                                             status
!amzn-main/2014.09                                               amzn-main-Base                                                                         5019
!amzn-updates/2014.09                                            amzn-updates-Base                                                                      1178
...
```

Please see document http://man7.org/linux/man-pages/man8/yum.8.html:

>In  non-verbose  mode  the  first column will start with a ´*´ if the repo. has metalink data and the latest metadata is not local and will start with a ´!´ if the repo. has metadata that is expired (this can happen due to metadata_expire_filter). For non-verbose mode  the  last column  will  also  display  the  number  of  packages  in  the repo. and (if there are any user specified excludes) the number of packages
 excluded.