### PR TITLE
Use `Get-Content` instead of `ReadAllText` to read file contents on Win

### DIFF
--- a/lib/specinfra/command/windows/base/file.rb
+++ b/lib/specinfra/command/windows/base/file.rb
@@ -36,7 +36,7 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
     end
 
     def get_content(file)
-      %Q![Io.File]::ReadAllText("#{file}")!
+      %Q!Get-Content("#{file}") | Out-String!
     end
 
     def check_is_accessible_by_user(file, user, access)
@@ -73,7 +73,7 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
 
     def check_contains(file, pattern)
       Backend::PowerShell::Command.new do
-        exec %Q![Io.File]::ReadAllText("#{file}") -match '#{convert_regexp(pattern)}'!
+        exec %Q!(Get-Content("#{file}") | Out-String) -match '#{convert_regexp(pattern)}'!
       end
     end
 
@@ -82,7 +82,7 @@ class Specinfra::Command::Windows::Base::File < Specinfra::Command::Windows::Bas
       to ||= '$'
       Backend::PowerShell::Command.new do
         using 'crop_text.ps1'
-        exec %Q!(CropText -text ([Io.File]::ReadAllText("#{file}")) -fromPattern '#{convert_regexp(from)}' -toPattern '#{convert_regexp(to)}') -match '#{pattern}'!
+        exec %Q!(CropText -text (Get-Content("#{file}") | Out-String) -fromPattern '#{convert_regexp(from)}' -toPattern '#{convert_regexp(to)}') -match '#{pattern}'!
       end
     end
 


### PR DESCRIPTION
Get-Content can read files that are in use by another process, such as log files, where ReadAllText can not.

Example output from powershell for the differences:

````
PS C:\Users\vagrant> [System.IO.File]::ReadAllText("C:\Windows\Temp\test.log")
Exception calling "ReadAllText" with "1" argument(s): "The process cannot access the file 'C:\Window
cause it is being used by another process."
At line:1 char:30
+ [System.IO.File]::ReadAllText <<<< ("C:\Windows\Temp\test.log")
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : DotNetMethodException

PS C:\Users\vagrant> (Get-Content("C:\windows\Temp\test.log") | Out-String)
2015-04-14 03:32:07 nil INFO -> -> MARK <- <-
2015-04-14 03:33:16 nil INFO -> -> MARK <- <-
2015-04-14 03:34:16 nil INFO -> -> MARK <- <-
2015-04-14 03:35:16 nil INFO -> -> MARK <- <-
2015-04-14 03:36:16 nil INFO -> -> MARK <- <-
````