### PR TITLE
Implement 'bond' type for OpenBSD

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -192,6 +192,7 @@ require 'specinfra/command/freebsd/v10/package'
 # OpenBSD (inherit Base)
 require 'specinfra/command/openbsd'
 require 'specinfra/command/openbsd/base'
+require 'specinfra/command/openbsd/base/bond'
 require 'specinfra/command/openbsd/base/bridge'
 require 'specinfra/command/openbsd/base/file'
 require 'specinfra/command/openbsd/base/interface'

--- a/lib/specinfra/command/openbsd/base/bond.rb
+++ b/lib/specinfra/command/openbsd/base/bond.rb
@@ -1,0 +1,11 @@
+class Specinfra::Command::Openbsd::Base::Bond < Specinfra::Command::Base::Bond
+  class << self
+    def check_exists(name)
+      "ifconfig #{name}"
+    end
+
+    def check_has_interface(name, interface)
+      "ifconfig #{name} | grep -o #{interface}"
+    end
+  end
+end


### PR DESCRIPTION
While OpenBSD doesn't have a 'bond' driver, the equivalent is 'trunk'
which can also combine multiple interfaces into a single logical interface.