### PR TITLE
update debian service check for multiple matches

### DIFF
--- a/lib/specinfra/command/debian/base/service.rb
+++ b/lib/specinfra/command/debian/base/service.rb
@@ -2,7 +2,7 @@ class Specinfra::Command::Debian::Base::Service < Specinfra::Command::Linux::Bas
   class << self
     def check_is_enabled(service, level=3)
       # Until everything uses Upstart, this needs an OR.
-      "ls /etc/rc#{level}.d/ | grep -- '^S..#{escape(service)}' || grep 'start on' /etc/init/#{escape(service)}.conf"
+      "ls /etc/rc#{level}.d/ | grep -- '^S..#{escape(service)}$' || grep 'start on' /etc/init/#{escape(service)}.conf"
     end
 
     def enable(service)


### PR DESCRIPTION
In the event that multiple entries of a similarly-named service exist,
the pattern matching will incorrectly report that the described service is
enabled, when it is disabled.

In this example, two services exist, `nginx` and `nginx-example`.

With the current regular expression passed to grep, `is_enabled`
incorrectly returns that nginx is enabled.

    expected Service "nginx" not to be enabled
    /bin/sh -c ls\ /etc/rc3.d/\ \|\ grep\ --\ \'\^S..nginx\'\ \|\|\ grep\ \'start\ on\'\ /etc/init/nginx.conf
    S20nginx-example

As can be seen on disk, the `nginx` service is prepended with `K` as it
is disabled, but the grep will respond with a different service.

    root@fcf39505054b:~# ls /etc/rc3.d/
    K80nginx  README  S20nginx-example  S99rc.local
    root@fcf39505054b:~# ls /etc/rc3.d/ | grep -- '^S..nginx' ; echo $?
    S20nginx-example
    0

By modifying the regular expression to end the string, we can ensure
that the described service is the only one that is matched against:

    root@fcf39505054b:~# ls /etc/rc3.d/ | grep -- '^S..nginx$' ; echo $?
    1

I looked around for any tests that cover this behavior already, and could not find any that seemed to match this behavior. I'd be happy to try and figure that out, given some advice on where they would go.