### PR TITLE
Expand check_is_installed_by_pear to check all channels, not just default channel.

### DIFF
--- a/lib/specinfra/command/base/package.rb
+++ b/lib/specinfra/command/base/package.rb
@@ -29,7 +29,7 @@ class Specinfra::Command::Base::Package < Specinfra::Command::Base
 
     def check_is_installed_by_pear(name, version=nil)
       regexp = "^#{name}"
-      cmd = "pear list | grep -iw -- #{escape(regexp)}"
+      cmd = "pear list -a | grep -iw -- #{escape(regexp)}"
       cmd = "#{cmd} | grep -w -- #{escape(version)}" if version
       cmd
     end


### PR DESCRIPTION
I would like to see the check_is_installed_by_pear method search for all pear packages across channels.  For example, the PHP redis library, Predis, comes from the pear.nrk.io channel, which doesn't show up in a `pear list` command.  `pear list -a` is needed to show Predis is installed.

`pear list` only shows installed packages in the default channel.
`pear list -a` shows all installed packages in all channels.

Found a reference online here: http://www.funkydata.net/2008/06/pear-list-installed-packages.html

And here is the difference between the two:

**pear list**
```
vagrant@vagrant-ubuntu-trusty-64:~$ pear list
Installed packages, channel pear.php.net:
=========================================
Package          Version State
Archive_Tar      1.3.11  stable
Console_Getopt   1.3.1   stable
Mail             1.2.0   stable
Net_SMTP         1.4.2   stable
Net_Socket       1.0.14  stable
PEAR             1.9.4   stable
Structures_Graph 1.0.4   stable
XML_Util         1.2.1   stable
```

**pear list -a**
```
vagrant@vagrant-ubuntu-trusty-64:~$ pear list -a
Installed packages, channel __uri:
==================================
(no packages installed)

Installed packages, channel doc.php.net:
========================================
(no packages installed)

Installed packages, channel pear.nrk.io:
========================================
Package Version State
Predis  0.8.3   stable

Installed packages, channel pear.php.net:
=========================================
Package          Version State
Archive_Tar      1.3.11  stable
Console_Getopt   1.3.1   stable
Mail             1.2.0   stable
Net_SMTP         1.4.2   stable
Net_Socket       1.0.14  stable
PEAR             1.9.4   stable
Structures_Graph 1.0.4   stable
XML_Util         1.2.1   stable

Installed packages, channel pecl.php.net:
=========================================
Package  Version State
apcu     4.0.2   beta
memcache 3.0.8   beta
```