### PR TITLE
replace netstat with ss for base port checking

### DIFF
--- a/lib/specinfra/command/base/port.rb
+++ b/lib/specinfra/command/base/port.rb
@@ -4,7 +4,7 @@ class Specinfra::Command::Base::Port < Specinfra::Command::Base
       pattern = ":#{port} "
       pattern = " #{options[:local_address]}#{pattern}" if options[:local_address]
       pattern = "^#{options[:protocol]} .*#{pattern}" if options[:protocol]
-      "netstat -tunl | grep -- #{escape(pattern)}"
+      "ss -tunl | grep -- #{escape(pattern)}"
     end
   end
 end


### PR DESCRIPTION
The net-tools package has been deprecated for some time (see references).

In most modern Linux distributions, this is now replaced by the `iproute2`
package, specifically the `ss` command. Some distributions do not include the
`net-tools` package at all, making this workaround necessary:

    packager = os[:family] == 'redhat' ? 'yum' : 'apt-get'
    expect((command "#{packager} install net-tools").exit_status).to eq 0

    expect(port 80).to be_listening

The output of `Specinfra::Command::Base::Port` will continue to work with the
replacement `ss`, as the evaluation is only looking for a valid entry, not the
order of fields.

For other platforms such as AIX, OpenBSD, Solaris, and Windows, this should be
evaluated for each platform and the abilities of the tooling in place by default.

Here's an example of a replacement of `netstat` with `ss` on debian 7:

    root@085b2730a0d3:~# netstat -tunl | grep -- 80
    tcp        0      0 0.0.0.0:80              0.0.0.0:*               LISTEN
    tcp6       0      0 :::80                   :::*                    LISTEN
    root@085b2730a0d3:~# ss -tunl | grep -- 80
    tcp    LISTEN     0      128                   :::80                   :::*
    tcp    LISTEN     0      128                    *:80                    *:*

References:
  - http://net-tools.sourceforge.net/man/netstat.8.html
  - https://www.archlinux.org/news/deprecation-of-net-tools/