### PR TITLE
Check HKEY_CURRENT_USER in addition to HKEY_LOCAL_MACHINE

### DIFF
--- a/lib/specinfra/backend/powershell/support/find_installed_application.ps1
+++ b/lib/specinfra/backend/powershell/support/find_installed_application.ps1
@@ -4,12 +4,27 @@ function FindInstalledApplication
     
   if ((Get-WmiObject win32_operatingsystem).OSArchitecture -notmatch '64')  
   { 
-      $keys= (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*') 
+    $keys= (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*')
+    $possible_path= 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    if (Test-Path $possible_path)
+    {
+      $keys+= (Get-ItemProperty $possible_path)
+    }
   }  
     else  
   { 
-      $keys = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*') 
-  }   
+    $keys = (Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\*','HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*')
+    $possible_path= 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    if (Test-Path $possible_path)
+    {
+      $keys+= (Get-ItemProperty $possible_path)
+    }
+    $possible_path= 'HKCU:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\*'
+    if (Test-Path $possible_path)
+    {
+      $keys+= (Get-ItemProperty $possible_path)
+    }
+  }
 
   if ($appVersion -eq $null) { 
     @($keys | Where-Object {$_.DisplayName -like $appName -or $_.PSChildName -like $appName}).Length -gt 0


### PR DESCRIPTION
Some Windows applications only install for the current user, so the registry keys end up under HKEY_CURRENT_USER and the package test fails. This change checks if the Uninstall paths also exist under `HKCU:\` and, if they do, searches there too.

This works in my testing, though I'm new to PowerShell. Hopefully it's not too ugly. :smile: 