### PR TITLE
Check service name for systemd module

### DIFF
--- a/lib/specinfra/command/module/systemd.rb
+++ b/lib/specinfra/command/module/systemd.rb
@@ -6,7 +6,7 @@ module Specinfra
           if level.to_s =~ /^\d+$/
             level = "runlevel#{level}.target"
           end
-          unless service.include?('.')
+          unless service.match(/\.(service|mount|device|socket)$/)
             service += '.service'
           end
 


### PR DESCRIPTION
Now only checks for a dot in service name, which causes an error with service names like "postgresql-9.3"

It should check explicitly for ".service" suffix (better, all known units suffixes, to avoid conflicts with .socket and similar)