### PR TITLE
Interface state

### DIFF
--- a/lib/specinfra/command/linux/base/interface.rb
+++ b/lib/specinfra/command/linux/base/interface.rb
@@ -29,6 +29,11 @@ class Specinfra::Command::Linux::Base::Interface < Specinfra::Command::Base::Int
       ip_address.downcase!
       "ip addr show #{interface} | grep 'inet6 #{ip_address}'"
     end
+
+    def check_is_up(name)
+      state = "cat /sys/class/net/#{name}/operstate"
+      state.strip == 'up'
+    end
   end
 end
 

--- a/lib/specinfra/command/linux/base/interface.rb
+++ b/lib/specinfra/command/linux/base/interface.rb
@@ -30,9 +30,8 @@ class Specinfra::Command::Linux::Base::Interface < Specinfra::Command::Base::Int
       "ip addr show #{interface} | grep 'inet6 #{ip_address}'"
     end
 
-    def check_is_up(name)
-      state = "cat /sys/class/net/#{name}/operstate"
-      state.strip == 'up'
+    def get_link_state(name)
+      "cat /sys/class/net/#{name}/operstate"
     end
   end
 end

--- a/spec/command/linux/interface_spec.rb
+++ b/spec/command/linux/interface_spec.rb
@@ -6,3 +6,7 @@ set :os, :family => 'linux'
 describe get_command(:check_interface_has_ipv6_address, 'eth0', '2001:0db8:bd05:01d2:288a:1fc0:0001:10ee') do
   it { should eq "ip addr show eth0 | grep 'inet6 2001:0db8:bd05:01d2:288a:1fc0:0001:10ee/'" }
 end
+
+describe get_command(:get_interface_link_state, 'eth0') do
+  it { should eq "cat /sys/class/net/eth0/operstate" }
+end


### PR DESCRIPTION
Add the get_link_state method for Linux interfaces to support the be_up? matcher.