### PR TITLE
Support commands for home dir & login shell on darwin

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -128,6 +128,7 @@ require 'specinfra/command/darwin/base/host'
 require 'specinfra/command/darwin/base/service'
 require 'specinfra/command/darwin/base/package'
 require 'specinfra/command/darwin/base/port'
+require 'specinfra/command/darwin/base/user'
 
 # Debian (inherit Linux)
 require 'specinfra/command/debian'

--- a/lib/specinfra/command/darwin/base/user.rb
+++ b/lib/specinfra/command/darwin/base/user.rb
@@ -1,0 +1,15 @@
+class Specinfra::Command::Darwin::Base::User < Specinfra::Command::Base::User
+  class << self
+    def check_has_home_directory(user, path_to_home)
+      "#{get_home_directory(user)} | grep -E '^#{escape(path_to_home)}$'"
+    end
+
+    def check_has_login_shell(user, path_to_shell)
+      "finger #{escape(user)} | grep -E '^Directory' | awk '{ print $4 }' | grep -E '^#{escape(path_to_shell)}$'"
+    end
+
+    def get_home_directory(user)
+      "finger #{escape(user)} | grep -E '^Directory' | awk '{ print $2 }'"
+    end
+  end
+end

--- a/spec/command/darwin/user_spec.rb
+++ b/spec/command/darwin/user_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+set :os, { :family => 'darwin' }
+
+describe get_command(:check_user_has_home_directory, 'foo', '/Users/foo') do
+  it { should eq "finger foo | grep -E '^Directory' | awk '{ print $2 }' | grep -E '^/Users/foo$'" }
+end
+
+describe get_command(:check_user_has_login_shell, 'foo', '/bin/bash') do
+  it { should eq "finger foo | grep -E '^Directory' | awk '{ print $4 }' | grep -E '^/bin/bash$'" }
+end
+
+describe get_command(:get_user_home_directory, 'foo') do
+  it { should eq "finger foo | grep -E '^Directory' | awk '{ print $2 }'" }
+end


### PR DESCRIPTION
This change adds the following 3 methods for darwin:

- check_has_home_directory
- check_has_login_shell
- get_home_directory

Because there is no `getent` command on darwin, we use [finger](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/finger.1.html) command instead. Here is an example output of `finger` command in my environment (Mac OS X 10.9.5)

```
$ finger r7kamura
Login: r7kamura       			Name: r7kamura
Directory: /Users/r7kamura          	Shell: /bin/zsh
On since 土  5  2 15:06 (JST) on console, idle 9 days 8:46 (messages off)
On since 土  5  2 15:06 (JST) on tty?? (messages off)
On since 月  5 11 16:00 (JST) on ttys000, idle 4:15
On since 木  5  7 06:55 (JST) on ttys001, idle 6:06
On since 木  5  7 06:45 (JST) on ttys002, idle 3 days 5:35
On since 木  5  7 06:56 (JST) on ttys003, idle 0:23
On since 日  5 10 18:18 (JST) on ttys004, idle 0:23
On since 月  5 11 23:18 (JST) on ttys005, idle 0:06
On since 土  5  9 05:44 (JST) on ttys006, idle 0:06
On since 月  5 11 23:19 (JST) on ttys007
On since 月  5 11 23:36 (JST) on ttys008, idle 0:05
On since 月  5 11 23:36 (JST) on ttys009 (messages off)
No Mail.
No Plan.
$ finger r7kamura | grep -E '^Directory' | awk '{ print $2 }' | grep -E '^/Users/r7kamura$'
/Users/r7kamura
$ finger r7kamura | grep -E '^Directory' | awk '{ print $4 }' | grep -E '^/bin/zsh$'
/bin/zsh
```