### PR TITLE
add check_file_exists

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -76,6 +76,10 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
       "grep -qFs -- #{escape(expected_pattern)} #{escape(file)}"
     end
 
+    def check_exists(file)
+      "test -e #{escape(file)}"
+    end
+
     def get_md5sum(file)
       "md5sum #{escape(file)} | cut -d ' ' -f 1"
     end

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -66,3 +66,6 @@ describe get_command(:get_file_link_target, '/tmp') do
   it { should eq 'readlink -f /tmp' }
 end
 
+describe get_command(:check_file_exists, '/tmp') do
+  it { should eq 'test -e /tmp' }
+end


### PR DESCRIPTION
When doing negative testing, I.e., asserting that 'this' path should not exist, it would be more concise to be able to express this in serverspec as:

```
describe File('/does_not_exist') do
  it { should_not exist }
end
```

This PR adds necessary plumbing to specinfra to be able to implement this functionality in serverspec.