### PR TITLE
Add `should be_installed.by 'homebrew_cask'`

### DIFF
--- a/lib/specinfra/command/darwin/base/package.rb
+++ b/lib/specinfra/command/darwin/base/package.rb
@@ -12,6 +12,16 @@ class Specinfra::Command::Darwin::Base::Package < Specinfra::Command::Base::Pack
 
     alias :check_is_installed_by_homebrew :check_is_installed
 
+    def check_is_installed_by_homebrew_cask(package, version=nil)
+      escaped_package = escape(package)
+      if version
+        cmd = "/usr/local/bin/brew cask info #{escaped_package} | grep -E '^\/opt\/homebrew-cask\/Caskroom\/#{escaped_package}\/#{escape(version)}'"
+      else
+        cmd = "/usr/local/bin/brew cask list -1 | grep -E '^#{escaped_package}$'"
+      end
+      cmd
+    end
+
     def check_is_installed_by_pkgutil(package, version=nil)
       cmd = "pkgutil --pkg-info #{package}"
       cmd = "#{cmd} | grep '^version: #{escape(version)}'" if version


### PR DESCRIPTION
`should be_installed.by('homebrew')` is already including in specinfra.
But I can't find testing for homebrew-cask.

This pr be able to express this in serverspec as:

```ruby
describe package('vagrant') do
  it { should be_installed.by('homebrew_cask') }
end
# or
describe package('vagrant') do
  it { should be_installed.by('homebrew_cask').with_version('1.7.2') }
end
```

But I think this pr is not good because brew-cask can install only OSX.
I want to tell me if you have idea to test homebrew-cask. or close this pr if it is unnecessary.
