### PR TITLE
Fix disable_under_daemontools

### DIFF
--- a/lib/specinfra/command/module/service/daemontools.rb
+++ b/lib/specinfra/command/module/service/daemontools.rb
@@ -16,7 +16,7 @@ module Specinfra
           end
 
           def disable_under_daemontools(service)
-            "( cd /service/#{escape(service)} && rm -f /service/#{escape(service)} && svc -dx . && [ -d log ] && svc -dx log )"
+            "( cd /service/#{escape(service)} && rm -f /service/#{escape(service)} && svc -dx . log )"
           end
 
           def start_under_daemontools(service)

--- a/spec/command/module/service/daemontools_spec.rb
+++ b/spec/command/module/service/daemontools_spec.rb
@@ -8,7 +8,7 @@ describe Specinfra::Command::Module::Service::Daemontools do
   it { expect(klass.check_is_enabled_under_daemontools('httpd')).to eq "test -L /service/httpd && test -f /service/httpd/run" }
   it { expect(klass.check_is_running_under_daemontools('httpd')).to eq "svstat /service/httpd | grep -E 'up \\(pid [0-9]+\\)'" }
   it { expect(klass.enable_under_daemontools('httpd', '/tmp/service/httpd')).to eq 'ln -snf /tmp/service/httpd /service/httpd' }
-  it { expect(klass.disable_under_daemontools('httpd')).to eq '( cd /service/httpd && rm -f /service/httpd && svc -dx . && [ -d log ] && svc -dx log )' }
+  it { expect(klass.disable_under_daemontools('httpd')).to eq '( cd /service/httpd && rm -f /service/httpd && svc -dx . log )' }
   it { expect(klass.start_under_daemontools('httpd')).to   eq 'svc -u /service/httpd' }
   it { expect(klass.stop_under_daemontools('httpd')).to    eq 'svc -d /service/httpd' }
   it { expect(klass.restart_under_daemontools('httpd')).to eq 'svc -t /service/httpd' }


### PR DESCRIPTION
Needed a small fix for https://github.com/serverspec/specinfra/pull/387

`[ -d log ] && svc -d log` exits with code 1 if `log` directory does not exist.

`svc -dx . log` outputs

```
svc: warning: unable to chdir to log: file does not exist
```

but, its exit code is 0. Let us use `svc -dx . log`.

https://github.com/hirose31/chef-provider-service-daemontools/blob/1a2aeb34cb604d637539601c1e0de8fec596be3c/lib/chef/provider/service/daemontools.rb#L58 is doing the same thing. 