### PR TITLE
Fix problem with spec failing because of periods.

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -110,7 +110,7 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
     end
 
     def check_is_linked_to(link, target)
-      "stat -c %N #{escape(link)} | egrep -e \"-> .#{escape(target)}.\""
+      "stat -c %N #{escape(link)} | egrep -e \"-> #{escape(target)}\""
     end
 
     def check_is_link(link)

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -69,3 +69,7 @@ end
 describe get_command(:check_file_exists, '/tmp') do
   it { should eq 'test -e /tmp' }
 end
+
+describe get_command(:check_file_is_linked_to, '/tmp', '/var/tmp') do
+  it { should eq 'stat -c %N /tmp | egrep -e "-> /var/tmp"' }
+end


### PR DESCRIPTION
I am not sure why these periods were added here. If there's another
operating system that puts them there perhaps it should be
overloaded.

The actual test:
```ruby
describe file('/srv/twbs/current') do
  it { should be_symlink }
  it { should be_linked_to '/srv/tws/3.3.4' }
end
```

What is returned when running serverspec:
```sh
    Failures:

         1) File "/srv/twbs/current" should be linked to "/srv/tws/3.3.4"
            Failure/Error: it { should be_linked_to '/srv/tws/3.3.4' }
              expected `File "/srv/twbs/current".linked_to?("/srv/tws/3.3.4")` to return true, got false
              /bin/sh -c stat\ -c\ \%N\ /srv/twbs/current\ \|\ egrep\ -e\ \"-\>\ ./srv/tws/3.3.4.\"

            # /tmp/verifier/suites/serverspec/default_spec.rb:11:in `block (2 levels) in <top (required)>'
```

On CentOS 6.6:
```sh
[vagrant@default-centos-66 ~]$ sudo stat -c %N /srv/twbs/current
`/srv/twbs/current' -> `/srv/twbs/3.3.4'
```

On CentOS 7.1:
```sh
[vagrant@default-centos-71 ~]$ sudo stat -c %N /srv/twbs/current
‘/srv/twbs/current’ -> ‘/srv/twbs/3.3.4’
```

On Ubuntu 12.04:
```sh
vagrant@default-ubuntu-1204:~$ sudo stat -c %N /srv/twbs/current
`/srv/twbs/current' -> `/srv/twbs/3.3.4'
```

On Ubuntu 14.04:
```sh
vagrant@default-ubuntu-1404:~$ sudo stat -c %N /srv/twbs/current
`/srv/twbs/current' -> `/srv/twbs/3.3.4'
```