### PR TITLE
add config ssh_without_env to skip sending envs

### DIFF
--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -9,8 +9,13 @@ module Specinfra
       def run_command(cmd, opt={})
         cmd = build_command(cmd)
         cmd = add_pre_command(cmd)
-        ret = with_env do
-          ssh_exec!(cmd)
+
+        if get_config(:ssh_without_env)
+          ret = ssh_exec!(cmd)
+        else
+          ret = with_env do
+            ssh_exec!(cmd)
+          end
         end
 
         ret[:stdout].gsub!(/\r\n/, "\n")

--- a/lib/specinfra/configuration.rb
+++ b/lib/specinfra/configuration.rb
@@ -19,6 +19,7 @@ module Specinfra
         :lxc,
         :request_pty,
         :ssh_options,
+        :ssh_without_env,
         :dockerfile_finalizer,
         :telnet_options,
       ].freeze


### PR DESCRIPTION
Hi, I've add ssh_without_env option to configration.

Example of usage following.  

```
## Is locale set correctly to specific user ?

require 'spec_helper'

## For specific user.
describe command('sudo -i -u vagrant locale') do
  let(:ssh_without_env) { true }
  its(:stdout) { should match "en_US.UTF-8" }
end

## For default login user.
describe command('sh -l -c "locale"') do
  #  by default => let(:ssh_without_env) { false }
  its(:stdout) { should match "C" }
end

## Default behavior
describe command('sh -l -c "locale"') do
  #  by default => let(:ssh_without_env) { false }
  its(:stdout) { should match "C" }
end

#=>

Command "sudo -i -u vagrant locale"
  stdout
    should match "en_US.UTF-8"

Command "sh -l -c "locale""
  stdout
    should match "C"

Command "sh -l -c "locale""
  stdout
    should match "C"

Finished in 0.77259 seconds (files took 5.72 seconds to load)
3 examples, 0 failures
```