### PR TITLE
rails when failed os detection

### DIFF
--- a/lib/specinfra/helper/os.rb
+++ b/lib/specinfra/helper/os.rb
@@ -21,6 +21,7 @@ module Specinfra
             return res
           end
         end
+        raise NotImplementedError, "Specinfra failed os detection. You should set os family to spec_helper. (or implement by own and create pull request)."
       end
     end
   end

--- a/lib/specinfra/helper/os.rb
+++ b/lib/specinfra/helper/os.rb
@@ -21,7 +21,7 @@ module Specinfra
             return res
           end
         end
-        raise NotImplementedError, "Specinfra failed os detection. You should set os family to spec_helper. (or implement by own and create pull request)."
+        raise NotImplementedError, "Specinfra failed os detection."
       end
     end
   end


### PR DESCRIPTION
`detect_os`の処理で検出を全部抜けると、戻り値が`Specinfra::Helper::DetectOs.subclasses`の結果(Array)になるけどもそのまま進んでしまいます。そのあと、command_factoryまで行ってこけてしまう。

ひとまず例外を出してメッセージを表示するのはどうでしょう。