### PR TITLE
Implement Process::get on Windows

### DIFF
--- a/lib/specinfra/command/windows/base/process.rb
+++ b/lib/specinfra/command/windows/base/process.rb
@@ -5,5 +5,27 @@ class Specinfra::Command::Windows::Base::Process < Specinfra::Command::Windows::
         exec "(Get-Process '#{process}') -ne $null"
       end
     end
+
+    def get(process, opts)
+      column = opts[:format].chomp '='
+
+      case column
+      when 'pid'
+        # map 'pid' to its windows equivalent
+        get_process_property(process, 'processid')
+      when 'user'
+        %Q!gwmi win32_process -filter "name = '#{process}'" | select -first 1 | %{$_.getowner().user}!
+      when 'group'
+        # no concept of process group on Windows
+        raise NotImplementedError.new('Unable to get process group on Windows')
+      else
+        get_process_property(process, column)
+      end
+    end
+
+    private
+    def get_process_property(process, property)
+      %Q!Get-WmiObject Win32_Process -Filter "name = '#{process}'" | select -First 1 #{property} -ExpandProperty #{property}!
+    end
   end
 end


### PR DESCRIPTION
Enables things such as:
```ruby
describe process("powershell.exe") do
  it { should be_running }
  its(:user) { should eq('vagrant') }
end
```

It didn't appear necessary to reimplement `check_is_running` in order to be able to use `be_running`.