### PR TITLE
Support daemontools service dir in /etc

### DIFF
--- a/lib/specinfra/command/module/service/daemontools.rb
+++ b/lib/specinfra/command/module/service/daemontools.rb
@@ -4,36 +4,41 @@ module Specinfra
       module Service
         module Daemontools
           def check_is_enabled_under_daemontools(service)
-            "test -L /service/#{escape(service)} && test -f /service/#{escape(service)}/run"
+            "test -L #{service_dir}/#{escape(service)} && test -f #{service_dir}/#{escape(service)}/run"
           end
 
           def check_is_running_under_daemontools(service)
-            "svstat /service/#{escape(service)} | grep -E 'up \\(pid [0-9]+\\)'"
+            "svstat #{service_dir}/#{escape(service)} | grep -E 'up \\(pid [0-9]+\\)'"
           end
 
           def enable_under_daemontools(service, directory)
-            "ln -snf #{escape(directory)} /service/#{escape(service)}"
+            "ln -snf #{escape(directory)} #{service_dir}/#{escape(service)}"
           end
 
           def disable_under_daemontools(service)
-            "( cd /service/#{escape(service)} && rm -f /service/#{escape(service)} && svc -dx . log )"
+            "( cd #{service_dir}/#{escape(service)} && rm -f #{service_dir}/#{escape(service)} && svc -dx . log )"
           end
 
           def start_under_daemontools(service)
-            "svc -u /service/#{escape(service)}"
+            "svc -u #{service_dir}/#{escape(service)}"
           end
 
           def stop_under_daemontools(service)
-            "svc -d /service/#{escape(service)}"
+            "svc -d #{service_dir}/#{escape(service)}"
           end
 
           def restart_under_daemontools(service)
-            "svc -t /service/#{escape(service)}"
+            "svc -t #{service_dir}/#{escape(service)}"
           end
 
           def reload_under_daemontools(service)
-            "svc -h /service/#{escape(service)}"
+            "svc -h #{service_dir}/#{escape(service)}"
           end
+
+	  private
+	  def service_dir
+	    '$([ -d /service ] && echo /service || echo /etc/service)'
+	  end
         end
       end
     end

--- a/spec/command/module/service/daemontools_spec.rb
+++ b/spec/command/module/service/daemontools_spec.rb
@@ -5,14 +5,14 @@ describe Specinfra::Command::Module::Service::Daemontools do
     extend Specinfra::Command::Module::Service::Daemontools
   end
   let(:klass) { Specinfra::Command::Module::Service::Daemontools::Test }
-  it { expect(klass.check_is_enabled_under_daemontools('httpd')).to eq "test -L /service/httpd && test -f /service/httpd/run" }
-  it { expect(klass.check_is_running_under_daemontools('httpd')).to eq "svstat /service/httpd | grep -E 'up \\(pid [0-9]+\\)'" }
-  it { expect(klass.enable_under_daemontools('httpd', '/tmp/service/httpd')).to eq 'ln -snf /tmp/service/httpd /service/httpd' }
-  it { expect(klass.disable_under_daemontools('httpd')).to eq '( cd /service/httpd && rm -f /service/httpd && svc -dx . log )' }
-  it { expect(klass.start_under_daemontools('httpd')).to   eq 'svc -u /service/httpd' }
-  it { expect(klass.stop_under_daemontools('httpd')).to    eq 'svc -d /service/httpd' }
-  it { expect(klass.restart_under_daemontools('httpd')).to eq 'svc -t /service/httpd' }
-  it { expect(klass.reload_under_daemontools('httpd')).to  eq 'svc -h /service/httpd' }
+  it { expect(klass.check_is_enabled_under_daemontools('httpd')).to eq "test -L $([ -d /service ] && echo /service || echo /etc/service)/httpd && test -f $([ -d /service ] && echo /service || echo /etc/service)/httpd/run" }
+  it { expect(klass.check_is_running_under_daemontools('httpd')).to eq "svstat $([ -d /service ] && echo /service || echo /etc/service)/httpd | grep -E 'up \\(pid [0-9]+\\)'" }
+  it { expect(klass.enable_under_daemontools('httpd', '/tmp/service/httpd')).to eq 'ln -snf /tmp/service/httpd $([ -d /service ] && echo /service || echo /etc/service)/httpd' }
+  it { expect(klass.disable_under_daemontools('httpd')).to eq '( cd $([ -d /service ] && echo /service || echo /etc/service)/httpd && rm -f $([ -d /service ] && echo /service || echo /etc/service)/httpd && svc -dx . log )' }
+  it { expect(klass.start_under_daemontools('httpd')).to   eq 'svc -u $([ -d /service ] && echo /service || echo /etc/service)/httpd' }
+  it { expect(klass.stop_under_daemontools('httpd')).to    eq 'svc -d $([ -d /service ] && echo /service || echo /etc/service)/httpd' }
+  it { expect(klass.restart_under_daemontools('httpd')).to eq 'svc -t $([ -d /service ] && echo /service || echo /etc/service)/httpd' }
+  it { expect(klass.reload_under_daemontools('httpd')).to  eq 'svc -h $([ -d /service ] && echo /service || echo /etc/service)/httpd' }
 end
 
 


### PR DESCRIPTION
Ubuntu puts the service dir in /etc/service, so fall back to this directory if /service does not exist