### PR TITLE
Add checks for block_device and character_device

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -16,6 +16,14 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
       "test -S #{escape(file)}"
     end
 
+    def check_is_block_device(file)
+      "test -b #{escape(file)}"
+    end
+
+    def check_is_character_device(file)
+      "test -c #{escape(file)}"
+    end
+
     def check_is_symlink(file)
       "test -L #{escape(file)}"
     end

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -62,6 +62,14 @@ describe get_command(:check_file_is_pipe, '/tmp') do
   it { should eq 'test -p /tmp' }
 end
 
+describe get_command(:check_file_is_block_device, '/tmp') do
+  it { should eq 'test -b /tmp' }
+end
+
+describe get_command(:check_file_is_character_device, '/tmp') do
+  it { should eq 'test -c /tmp' }
+end
+
 describe get_command(:get_file_link_target, '/tmp') do
   it { should eq 'readlink /tmp' }
 end


### PR DESCRIPTION
These checks add to the ability of the file resource. It allows you to check if the specified device is a block device and/or a character device.