### PR TITLE
Modifying the AIX detect_os code to include the release and architecture

### DIFF
--- a/lib/specinfra/helper/detect_os/aix.rb
+++ b/lib/specinfra/helper/detect_os/aix.rb
@@ -1,7 +1,10 @@
 class Specinfra::Helper::DetectOs::Aix < Specinfra::Helper::DetectOs
   def detect
     if run_command('uname -s').stdout =~ /AIX/i
-      { :family => 'aix', :release => nil }
+      line = run_command('uname -rvp').stdout
+      if line =~ /(\d)\s+(\d)\s+(.*)/ then
+        { :family => 'aix', :release => "#{$2}.#{$1}", :arch => $3 }
+      end
     end
   end
 end


### PR DESCRIPTION
uname -rvp yields minor_release, major_release and architecture on AIX. Tested the code against an AIX 6.1 and 7.1 machine. The previous code displayed the machine ID number instead of the architecture (uname -m). With this fix the architecture is set to 'powerpc' on the hosts tested.