### PR TITLE
domain, fqdn and hostname inventory value returns nil if it fails.

### DIFF
--- a/lib/specinfra/host_inventory/domain.rb
+++ b/lib/specinfra/host_inventory/domain.rb
@@ -3,7 +3,13 @@ module Specinfra
     class Domain < Base
       def get
         cmd = backend.command.get(:get_inventory_domain)
-        backend.run_command(cmd).stdout.strip
+        result = backend.run_command(cmd)
+
+        if result.exit_status == 0
+          result.stdout.strip
+        else
+          nil
+        end
       end
     end
   end

--- a/lib/specinfra/host_inventory/fqdn.rb
+++ b/lib/specinfra/host_inventory/fqdn.rb
@@ -3,7 +3,13 @@ module Specinfra
     class Fqdn < Base
       def get
         cmd = backend.command.get(:get_inventory_fqdn)
-        backend.run_command(cmd).stdout.strip
+        result = backend.run_command(cmd)
+
+        if result.exit_status == 0
+          result.stdout.strip
+        else
+          nil
+        end
       end
     end
   end

--- a/lib/specinfra/host_inventory/hostname.rb
+++ b/lib/specinfra/host_inventory/hostname.rb
@@ -3,7 +3,13 @@ module Specinfra
     class Hostname < Base
       def get
         cmd = backend.command.get(:get_inventory_hostname)
-        backend.run_command(cmd).stdout.strip
+        result = backend.run_command(cmd)
+
+        if result.exit_status == 0
+          result.stdout.strip
+        else
+          nil
+        end
       end
     end
   end


### PR DESCRIPTION
I encountered that `domain` is set to `dnsdomainname: Name or service not known`. IMO, host inventory should return `nil` in such situation.