### PR TITLE
fix check group gid method

### DIFF
--- a/lib/specinfra/command/base/group.rb
+++ b/lib/specinfra/command/base/group.rb
@@ -5,8 +5,7 @@ class Specinfra::Command::Base::Group < Specinfra::Command::Base
     end
 
     def check_has_gid(group, gid)
-      regexp = "^#{group}"
-      "getent group | grep -w -- #{escape(regexp)} | cut -f 3 -d ':' | grep -w -- #{escape(gid)}"
+      "getent group #{escape(group)} | cut -f 3 -d ':' | grep -w -- #{escape(gid)}"
     end
 
     def get_gid(group)


### PR DESCRIPTION
The current `check_has_gid` function does not work universally. It fails on systems that cannot enumerate all groups on the system, such as those that use directory services to store user and group databases. This PR fixes this bug.