### PR TITLE
Adding darwin kernel release number

### DIFF
--- a/lib/specinfra/helper/detect_os/darwin.rb
+++ b/lib/specinfra/helper/detect_os/darwin.rb
@@ -1,7 +1,8 @@
 class Specinfra::Helper::DetectOs::Darwin < Specinfra::Helper::DetectOs
   def detect
     if run_command('uname -s').stdout =~ /Darwin/i
-      { :family => 'darwin', :release => nil }
+      release = run_command('uname -r').stdout.strip
+      { :family => 'darwin', :release => release }
     end
   end
 end


### PR DESCRIPTION
While this is not the MacOS release number for such a case a new key like friendly_name or such some is needed. 