### PR TITLE
detect_os/freebsd: Make release check more universally applicable

### DIFF
--- a/lib/specinfra/helper/detect_os/freebsd.rb
+++ b/lib/specinfra/helper/detect_os/freebsd.rb
@@ -1,8 +1,8 @@
 class Specinfra::Helper::DetectOs::Freebsd < Specinfra::Helper::DetectOs
   def detect
     if ( uname = run_command('uname -sr').stdout ) && uname =~ /FreeBSD/i
-      if uname =~ /10./
-        { :family => 'freebsd', :release => 10 }
+      if uname =~ /(\d+)\./
+        { :family => 'freebsd', :release => $1 }
       else
         { :family => 'freebsd', :release => nil }
       end


### PR DESCRIPTION
Checked against release 9.3