### PR TITLE
Add net-telnet dependency

### DIFF
--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "net-ssh"
   spec.add_runtime_dependency "net-scp"
+  spec.add_runtime_dependency "net-ssh"
+  spec.add_runtime_dependency "net-telnet"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1.1"


### PR DESCRIPTION
net/telnet will be removed from Ruby 2.3.
https://bugs.ruby-lang.org/issues/11083