### PR TITLE
systemd: Check by is-enabled subcommand

### DIFF
--- a/lib/specinfra/command/module/service/systemd.rb
+++ b/lib/specinfra/command/module/service/systemd.rb
@@ -3,15 +3,8 @@ module Specinfra
     module Module
       module Service
         module Systemd
-          def check_is_enabled_under_systemd(service, level="multi-user.target")
-            if level.to_s =~ /^\d+$/
-              level = "runlevel#{level}.target"
-            end
-            unless service.match(/\.(service|mount|device|socket)$/)
-              service += '.service'
-            end
-
-            "systemctl --plain list-dependencies #{level} | grep '\\(^\\| \\)#{escape(service)}$'"
+          def check_is_enabled_under_systemd(service, level=nil)
+            "systemctl --quiet is-enabled #{escape(service)}"
           end
 
           def check_is_running_under_systemd(service)

--- a/spec/command/module/service/systemd_spec.rb
+++ b/spec/command/module/service/systemd_spec.rb
@@ -5,7 +5,7 @@ describe Specinfra::Command::Module::Service::Systemd do
     extend Specinfra::Command::Module::Service::Systemd
   end
   let(:klass) { Specinfra::Command::Module::Service::Systemd::Test }
-  it { expect(klass.check_is_enabled_under_systemd('httpd')).to eq "systemctl --plain list-dependencies multi-user.target | grep '\\(^\\| \\)httpd.service$'" }
+  it { expect(klass.check_is_enabled_under_systemd('httpd')).to eq "systemctl --quiet is-enabled httpd" }
   it { expect(klass.check_is_running_under_systemd('httpd')).to eq 'systemctl is-active httpd' }
   it { expect(klass.enable_under_systemd('httpd')).to  eq 'systemctl enable httpd' }
   it { expect(klass.disable_under_systemd('httpd')).to eq 'systemctl disable httpd' }

--- a/spec/command/module/systemd_spec.rb
+++ b/spec/command/module/systemd_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe Specinfra::Command::Redhat::V7::Service do
   let(:klass) { Specinfra::Command::Redhat::V7::Service }
-  it { expect(klass.check_is_enabled('httpd')).to eq "systemctl --plain list-dependencies multi-user.target | grep '\\(^\\| \\)httpd.service$'" }
-  it { expect(klass.check_is_enabled('httpd', 'multi-user.target')).to eq "systemctl --plain list-dependencies multi-user.target | grep '\\(^\\| \\)httpd.service$'" }
-  it { expect(klass.check_is_enabled('httpd', 3)).to eq "systemctl --plain list-dependencies runlevel3.target | grep '\\(^\\| \\)httpd.service$'" }
-  it { expect(klass.check_is_enabled('httpd', '3')).to eq "systemctl --plain list-dependencies runlevel3.target | grep '\\(^\\| \\)httpd.service$'" }
-  it { expect(klass.check_is_enabled('sshd.socket')).to eq "systemctl --plain list-dependencies multi-user.target | grep '\\(^\\| \\)sshd.socket$'" }
+  it { expect(klass.check_is_enabled('httpd')).to eq "systemctl --quiet is-enabled httpd" }
+  it { expect(klass.check_is_enabled('httpd', 'multi-user.target')).to eq "systemctl --quiet is-enabled httpd" }
+  it { expect(klass.check_is_enabled('httpd.service')).to eq "systemctl --quiet is-enabled httpd.service" }
+  it { expect(klass.check_is_enabled('sshd.socket')).to eq "systemctl --quiet is-enabled sshd.socket" }
+  it { expect(klass.check_is_enabled('logrotate.timer')).to eq "systemctl --quiet is-enabled logrotate.timer" }
 end
 
 


### PR DESCRIPTION
There's many extensions for systemd units: .timer, .swap, .path, and so
on. The only stable way is to use `systemctl is-enabled` command.