### PR TITLE
spec/detect_os: Adding spec files for aix, darwin and freebsd

### DIFF
--- a/spec/helper/detect_os/aix_spec.rb
+++ b/spec/helper/detect_os/aix_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+require 'specinfra/helper/detect_os/aix'
+
+describe Specinfra::Helper::DetectOs::Aix do
+  aix = Specinfra::Helper::DetectOs::Aix.new(:exec)
+  it 'Should return aix 10.11 powerpc when (fictional) AIX 10.11 is installed.' do
+    allow(aix).to receive(:run_command).with('uname -s') {
+      CommandResult.new(:stdout => 'AIX', :exit_status => 0)
+    }
+    allow(aix).to receive(:run_command).with('uname -rvp') {
+      CommandResult.new(:stdout => '11 10 powerpc', :exit_status => 0)
+    }
+    expect(aix.detect).to include(
+      :family  => 'aix',
+      :release => '10.11',
+      :arch    => 'powerpc'
+    )
+  end
+  it 'Should return aix 7.1 powerpc when AIX 7.1 is installed.' do
+    allow(aix).to receive(:run_command).with('uname -s') {
+      CommandResult.new(:stdout => 'AIX', :exit_status => 0)
+    }
+    allow(aix).to receive(:run_command).with('uname -rvp') {
+      CommandResult.new(:stdout => '1 7 powerpc', :exit_status => 0)
+    }
+    expect(aix.detect).to include(
+      :family  => 'aix',
+      :release => '7.1',
+      :arch    => 'powerpc'
+    )
+  end
+  it 'Should return aix 6.1 powerpc when AIX 6.1 is installed.' do
+    allow(aix).to receive(:run_command).with('uname -s') {
+      CommandResult.new(:stdout => 'AIX', :exit_status => 0)
+    }
+    allow(aix).to receive(:run_command).with('uname -rvp') {
+      CommandResult.new(:stdout => '1 6 powerpc', :exit_status => 0)
+    }
+    expect(aix.detect).to include(
+      :family  => 'aix',
+      :release => '6.1',
+      :arch    => 'powerpc'
+    )
+  end
+  it 'Should return aix when AIX is installed.' do
+    allow(aix).to receive(:run_command).with('uname -s') {
+      CommandResult.new(:stdout => 'AIX', :exit_status => 0)
+    }
+    allow(aix).to receive(:run_command).with('uname -rvp') {
+      CommandResult.new(:stdout => '', :exit_status => 1)
+    }
+    expect(aix.detect).to include(
+      :family  => 'aix',
+      :release => nil,
+      :arch    => nil
+    )
+  end
+end

--- a/spec/helper/detect_os/darwin_spec.rb
+++ b/spec/helper/detect_os/darwin_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'specinfra/helper/detect_os/darwin'
+
+describe Specinfra::Helper::DetectOs::Darwin do
+  darwin = Specinfra::Helper::DetectOs::Darwin.new(:exec)
+  it 'Should return darwin 13.4.0 when Mac OS X 10.9.5 (Mavericks) is installed.' do
+    allow(darwin).to receive(:run_command).with('uname -s') {
+      CommandResult.new(:stdout => 'Darwin', :exit_status => 0)
+    }
+    allow(darwin).to receive(:run_command).with('uname -r') {
+      CommandResult.new(:stdout => '13.4.0', :exit_status => 0)
+    }
+    expect(darwin.detect).to include(
+      :family  => 'darwin',
+      :release => '13.4.0'
+    )
+  end
+  it 'Should return darwin 12.6.0 when Mac OS X 10.8.5 (Mountain Lion) is installed.' do
+    allow(darwin).to receive(:run_command).with('uname -s') {
+      CommandResult.new(:stdout => 'Darwin', :exit_status => 0)
+    }
+    allow(darwin).to receive(:run_command).with('uname -r') {
+      CommandResult.new(:stdout => '12.6.0', :exit_status => 0)
+    }
+    expect(darwin.detect).to include(
+      :family  => 'darwin',
+      :release => '12.6.0'
+    )
+  end
+  it 'Should return darwin 11.4.2 when Mac OS X 10.7.5 (Lion) is installed.' do
+    allow(darwin).to receive(:run_command).with('uname -s') {
+      CommandResult.new(:stdout => 'Darwin', :exit_status => 0)
+    }
+    allow(darwin).to receive(:run_command).with('uname -r') {
+      CommandResult.new(:stdout => '11.4.2', :exit_status => 0)
+    }
+    expect(darwin.detect).to include(
+      :family  => 'darwin',
+      :release => '11.4.2'
+    )
+  end
+end

--- a/spec/helper/detect_os/freebsd_spec.rb
+++ b/spec/helper/detect_os/freebsd_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'specinfra/helper/detect_os/freebsd'
+
+describe Specinfra::Helper::DetectOs::Freebsd do
+  freebsd = Specinfra::Helper::DetectOs::Freebsd.new(:exec)
+  it 'Should return freebsd 8 when FreeBSD 8.2-RELEASE-p3 is installed.' do
+    allow(freebsd).to receive(:run_command) {
+      CommandResult.new(:stdout => 'FreeBSD 8.2-RELEASE-p3', :exit_status => 0)
+    }
+    expect(freebsd.detect).to include(
+      :family  => 'freebsd',
+      :release => '8'
+    )
+  end
+  it 'Should return freebsd 9 when FreeBSD 9.3-RELEASE is installed.' do
+    allow(freebsd).to receive(:run_command) {
+      CommandResult.new(:stdout => 'FreeBSD 9.3-RELEASE', :exit_status => 0)
+    }
+    expect(freebsd.detect).to include(
+      :family  => 'freebsd',
+      :release => '9'
+    )
+  end
+  it 'Should return freebsd 10 when FreeBSD 10.1-RELEASE is installed.' do
+    allow(freebsd).to receive(:run_command) {
+      CommandResult.new(:stdout => 'FreeBSD 10.1--RELEASE', :exit_status => 0)
+    }
+    expect(freebsd.detect).to include(
+      :family  => 'freebsd',
+      :release => '10'
+    )
+  end
+end


### PR DESCRIPTION
For testing the os detetction code in aix, darwin and freebsd. 