### PR TITLE
Support user.rb in the Old FreeBSD.

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -216,6 +216,10 @@ require 'specinfra/command/freebsd/base/user'
 require 'specinfra/command/freebsd/v10'
 require 'specinfra/command/freebsd/v10/package'
 
+# FreeBSD V6 (inherit FreeBSD)
+require 'specinfra/command/freebsd/v6'
+require 'specinfra/command/freebsd/v6/user'
+
 # OpenBSD (inherit Base)
 require 'specinfra/command/openbsd'
 require 'specinfra/command/openbsd/base'

--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -210,6 +210,7 @@ require 'specinfra/command/freebsd/base/package'
 require 'specinfra/command/freebsd/base/port'
 require 'specinfra/command/freebsd/base/service'
 require 'specinfra/command/freebsd/base/routing_table'
+require 'specinfra/command/freebsd/base/user'
 
 # FreeBSD V10 (inherit FreeBSD)
 require 'specinfra/command/freebsd/v10'

--- a/lib/specinfra/command/freebsd/base/user.rb
+++ b/lib/specinfra/command/freebsd/base/user.rb
@@ -1,6 +1,5 @@
 class Specinfra::Command::Freebsd::Base::User < Specinfra::Command::Base::User
   class << self
-
     def get_minimum_days_between_password_change(user)
       "0"
     end

--- a/lib/specinfra/command/freebsd/base/user.rb
+++ b/lib/specinfra/command/freebsd/base/user.rb
@@ -1,5 +1,13 @@
 class Specinfra::Command::Freebsd::Base::User < Specinfra::Command::Base::User
   class << self
+    def create
+      if os[:release].to_i < 7
+        Specinfra::Command::Freebsd::V6::User
+      else
+        self
+      end
+    end
+
     def get_minimum_days_between_password_change(user)
       "0"
     end
@@ -7,6 +15,5 @@ class Specinfra::Command::Freebsd::Base::User < Specinfra::Command::Base::User
     def get_maximum_days_between_password_change(user)
       "pw usershow -n #{escape(user)} | cut -d':' -f 6"
     end
-
   end
 end

--- a/lib/specinfra/command/freebsd/v6.rb
+++ b/lib/specinfra/command/freebsd/v6.rb
@@ -1,0 +1,2 @@
+class Specinfra::Command::Freebsd::V6 < Specinfra::Command::Freebsd::Base
+end

--- a/lib/specinfra/command/freebsd/v6/user.rb
+++ b/lib/specinfra/command/freebsd/v6/user.rb
@@ -1,0 +1,19 @@
+class Specinfra::Command::Freebsd::V6::User < Specinfra::Command::Freebsd::Base::User
+  class << self
+    def check_has_home_directory(user, path_to_home)
+      "pw user show #{escape(user)} | cut -f 9 -d ':' | grep -w -- #{escape(path_to_home)}"
+    end
+
+    def check_has_login_shell(user, path_to_shell)
+      "pw user show #{escape(user)} | cut -f 10 -d ':' | grep -w -- #{escape(path_to_shell)}"
+    end
+
+    def get_home_directory(user)
+      "pw user show #{escape(user)} | cut -f 9 -d ':'"
+    end
+
+    def get_login_shell(user)
+      "pw user show #{escape(user)} | cut -f 10 -d ':'"
+    end
+  end
+end

--- a/lib/specinfra/version.rb
+++ b/lib/specinfra/version.rb
@@ -1,3 +1,3 @@
 module Specinfra
-  VERSION = "2.36.10"
+  VERSION = "2.36.11"
 end

--- a/lib/specinfra/version.rb
+++ b/lib/specinfra/version.rb
@@ -1,3 +1,3 @@
 module Specinfra
-  VERSION = "2.36.11"
+  VERSION = "2.36.12"
 end


### PR DESCRIPTION
FreeBSD old version don't have 'getent'.
It was imported into FreeBSD 7.0.

* check_has_home_directory
* check_has_login_shell
* get_home_directory
* get_login_shell
* get_encrypted_password

Use 'grep' instead of 'getent'

Test at FreeBSD 4.11 and 8.4