### PR TITLE
linux/check_attribute: fix failure when many attr are set

### DIFF
--- a/lib/specinfra/command/linux/base/file.rb
+++ b/lib/specinfra/command/linux/base/file.rb
@@ -9,7 +9,7 @@ class Specinfra::Command::Linux::Base::File < Specinfra::Command::Base::File
     end
 
     def check_attribute(file, attribute)
-      "lsattr -d #{escape(file)} 2>&1 | awk '$1~/^-*#{escape(attribute)}-*$/ {exit 0} {exit 1}'"
+      "lsattr -d #{escape(file)} 2>&1 | awk '$1~/#{escape(attribute)}/ {exit 0} {exit 1}'"
     end
 
     def get_selinuxlabel(file)

--- a/spec/command/linux/file_spec.rb
+++ b/spec/command/linux/file_spec.rb
@@ -3,6 +3,10 @@ require 'spec_helper'
 property[:os] = nil
 set :os, :family => 'linux'
 
+describe get_command(:check_file_is_immutable, 'some_file') do
+  it { should eq "lsattr -d some_file 2>&1 | awk '$1~/i/ {exit 0} {exit 1}'" } 
+end
+
 describe get_command(:get_file_selinuxlabel, 'some_file') do
   it { should eq 'stat -c %C some_file' }
 end


### PR DESCRIPTION
 The previous code did work when _only_ the immutable flag was set.
 When other attributes were added, although the file was still immutable,
 it would return exit status 1.
 This patch fixed the behaviour as outlined below.
 Before:
  'suS-iadAcj-t-e- /var/tmp/immutable' returns failure despite the presence of 'i'
  '----i---------- /var/tmp/immutable' returns success which is correct
  'suS--adAcj-t-e- /var/tmp/immutable' returns failure which is correct

 With fix:
  'suS-iadAcj-t-e- /var/tmp/immutable' returns success correctly as 'i' is present
  '----i---------- /var/tmp/immutable' returns success correctly as 'i' is present
  'suS--adAcj-t-e- /var/tmp/immutable' returns failure correctly as 'i' is not present