### PR TITLE
Change how to run command with exec backend

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -8,18 +8,16 @@ module Specinfra
       def run_command(cmd, opts={})
         cmd = build_command(cmd)
         cmd = add_pre_command(cmd)
-        stdout = with_env do
-          `#{cmd} 2>&1`
+        stdout, stderr, exit_status = with_env do
+          spawn_command(cmd)
         end
-        # In ruby 1.9, it is possible to use Open3.capture3, but not in 1.8
-        # stdout, stderr, status = Open3.capture3(cmd)
 
         if @example
           @example.metadata[:command] = cmd
           @example.metadata[:stdout]  = stdout
         end
 
-        CommandResult.new :stdout => stdout, :exit_status => $?.exitstatus
+        CommandResult.new :stdout => stdout, :stderr => stderr, :exit_status => exit_status
       end
 
       def send_file(from, to)
@@ -44,6 +42,59 @@ module Specinfra
       end
 
       private
+      def spawn_command(cmd)
+        stdout, stderr = '', ''
+
+        begin
+          quit_r, quit_w = IO.pipe
+          out_r,  out_w  = IO.pipe
+          err_r,  err_w  = IO.pipe
+
+          th = Thread.new do
+            begin
+              loop do
+                readable_ios, = IO.select([quit_r, out_r, err_r])
+
+                if readable_ios.include?(out_r)
+                  stdout += out_r.read_nonblock(1000)
+                end
+
+                if readable_ios.include?(err_r)
+                  stderr +=  err_r.read_nonblock(1000)
+                end
+
+                if readable_ios.include?(quit_r)
+                  break
+                end
+              end
+            rescue EOFError
+            ensure
+              quit_r.close unless quit_r.closed?
+              out_r.close  unless out_r.closed?
+              err_r.close  unless err_r.closed?
+            end
+          end
+
+          th.abort_on_exception = true
+
+          pid = spawn(cmd, :out => out_w, :err => err_w)
+
+          out_w.close
+          err_w.close
+
+          pid, stats = Process.waitpid2(pid)
+
+          begin
+            quit_w.syswrite 1
+          rescue Errno::EPIPE
+          end
+        ensure
+          quit_w.close
+        end
+
+        return stdout, stderr, stats.exitstatus
+      end
+
       def with_env
         keys = %w[BUNDLER_EDITOR BUNDLE_BIN_PATH BUNDLE_GEMFILE
             RUBYOPT GEM_HOME GEM_PATH GEM_CACHE]

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -90,7 +90,7 @@ module Specinfra
           rescue Errno::EPIPE
           end
         ensure
-          quit_w.close
+          quit_w.close unless quit_w.closed?
         end
 
         return stdout, stderr, stats.exitstatus

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -1,7 +1,7 @@
 require 'singleton'
 require 'fileutils'
 require 'shellwords'
-require 'posix-spawn'
+require 'sfl'
 
 module Specinfra
   module Backend
@@ -78,7 +78,7 @@ module Specinfra
 
           th.abort_on_exception = true
 
-          pid = POSIX::Spawn::spawn(cmd, :out => out_w, :err => err_w)
+          pid = spawn(cmd, :out => out_w, :err => err_w)
 
           out_w.close
           err_w.close

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -1,6 +1,7 @@
 require 'singleton'
 require 'fileutils'
 require 'shellwords'
+require 'posix-spawn'
 
 module Specinfra
   module Backend
@@ -77,7 +78,7 @@ module Specinfra
 
           th.abort_on_exception = true
 
-          pid = spawn(cmd, :out => out_w, :err => err_w)
+          pid = POSIX::Spawn::spawn(cmd, :out => out_w, :err => err_w)
 
           out_w.close
           err_w.close

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "net-ssh"
   spec.add_runtime_dependency "net-telnet"
-  spec.add_runtime_dependency "posix-spawn"
+  spec.add_runtime_dependency "sfl"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1.1"

--- a/specinfra.gemspec
+++ b/specinfra.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "net-scp"
   spec.add_runtime_dependency "net-ssh"
   spec.add_runtime_dependency "net-telnet"
+  spec.add_runtime_dependency "posix-spawn"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", "~> 10.1.1"


### PR DESCRIPTION
With the previouse way, if a grandchild process holds stdout or stderr,
the command hangs up.

I've changed the way to run command to fix it.

As a side effect, we can get sttderr correctly with exec backend.