### PR TITLE
Add check for Entrypoint configuration to docker backend

### DIFF
--- a/lib/specinfra/backend/docker.rb
+++ b/lib/specinfra/backend/docker.rb
@@ -58,7 +58,7 @@ module Specinfra
       def create_and_start_container
         opts = { 'Image' => current_image.id }
 
-        if current_image.json["Config"]["Cmd"].nil?
+        if current_image.json["Config"]["Cmd"].nil? && current_image.json["Config"]["Entrypoint"].nil?
           opts.merge!({'Cmd' => ['/bin/sh']})
         end
 


### PR DESCRIPTION
If set only ```Entrypoint``` instead of ```Cmd``` in Dockerfile, when start the container "/bin/sh" is passed as a parameter of ```Entrypoint``` by specinfra. There is a case to fail to start the container.

For this problem, check whether nil the ```Cmd``` and ```Entrypoint``` before you create a container