### PR TITLE
 detect_os: Better error handling for darwin and updated specs

### DIFF
--- a/lib/specinfra/helper/detect_os/darwin.rb
+++ b/lib/specinfra/helper/detect_os/darwin.rb
@@ -1,8 +1,11 @@
 class Specinfra::Helper::DetectOs::Darwin < Specinfra::Helper::DetectOs
   def detect
-    if run_command('uname -s').stdout =~ /Darwin/i
-      release = run_command('uname -r').stdout.strip
-      { :family => 'darwin', :release => release }
+    if ( uname = run_command('uname -sr').stdout ) && uname =~ /Darwin/i
+      if uname =~ /([\d.]+)$/
+         { :family => 'darwin', :release => $1 }
+      else 
+         { :family => 'darwin', :release => nil }
+      end
     end
   end
 end

--- a/spec/helper/detect_os/aix_spec.rb
+++ b/spec/helper/detect_os/aix_spec.rb
@@ -42,12 +42,12 @@ describe Specinfra::Helper::DetectOs::Aix do
       :arch    => 'powerpc'
     )
   end
-  it 'Should return aix when AIX is installed.' do
+  it 'Should return aix nil nil when AIX FooBar is installed.' do
     allow(aix).to receive(:run_command).with('uname -s') {
       CommandResult.new(:stdout => 'AIX', :exit_status => 0)
     }
     allow(aix).to receive(:run_command).with('uname -rvp') {
-      CommandResult.new(:stdout => '', :exit_status => 1)
+      CommandResult.new(:stdout => 'Foo Bar batz', :exit_status => 1)
     }
     expect(aix.detect).to include(
       :family  => 'aix',

--- a/spec/helper/detect_os/darwin_spec.rb
+++ b/spec/helper/detect_os/darwin_spec.rb
@@ -4,11 +4,8 @@ require 'specinfra/helper/detect_os/darwin'
 describe Specinfra::Helper::DetectOs::Darwin do
   darwin = Specinfra::Helper::DetectOs::Darwin.new(:exec)
   it 'Should return darwin 13.4.0 when Mac OS X 10.9.5 (Mavericks) is installed.' do
-    allow(darwin).to receive(:run_command).with('uname -s') {
-      CommandResult.new(:stdout => 'Darwin', :exit_status => 0)
-    }
-    allow(darwin).to receive(:run_command).with('uname -r') {
-      CommandResult.new(:stdout => '13.4.0', :exit_status => 0)
+    allow(darwin).to receive(:run_command) {
+      CommandResult.new(:stdout => 'Darwin 13.4.0', :exit_status => 0)
     }
     expect(darwin.detect).to include(
       :family  => 'darwin',
@@ -16,11 +13,8 @@ describe Specinfra::Helper::DetectOs::Darwin do
     )
   end
   it 'Should return darwin 12.6.0 when Mac OS X 10.8.5 (Mountain Lion) is installed.' do
-    allow(darwin).to receive(:run_command).with('uname -s') {
-      CommandResult.new(:stdout => 'Darwin', :exit_status => 0)
-    }
-    allow(darwin).to receive(:run_command).with('uname -r') {
-      CommandResult.new(:stdout => '12.6.0', :exit_status => 0)
+    allow(darwin).to receive(:run_command) {
+      CommandResult.new(:stdout => 'Darwin 12.6.0', :exit_status => 0)
     }
     expect(darwin.detect).to include(
       :family  => 'darwin',
@@ -28,15 +22,21 @@ describe Specinfra::Helper::DetectOs::Darwin do
     )
   end
   it 'Should return darwin 11.4.2 when Mac OS X 10.7.5 (Lion) is installed.' do
-    allow(darwin).to receive(:run_command).with('uname -s') {
-      CommandResult.new(:stdout => 'Darwin', :exit_status => 0)
-    }
-    allow(darwin).to receive(:run_command).with('uname -r') {
-      CommandResult.new(:stdout => '11.4.2', :exit_status => 0)
+    allow(darwin).to receive(:run_command) {
+      CommandResult.new(:stdout => 'Darwin 11.4.2', :exit_status => 0)
     }
     expect(darwin.detect).to include(
       :family  => 'darwin',
       :release => '11.4.2'
+    )
+  end
+  it 'Should return darwin nil when Darwin FooBar is installed.' do
+    allow(darwin).to receive(:run_command) {
+      CommandResult.new(:stdout => 'Darwin FooBar', :exit_status => 0)
+    }
+    expect(darwin.detect).to include(
+      :family  => 'darwin',
+      :release => nil
     )
   end
 end

--- a/spec/helper/detect_os/esxi_spec.rb
+++ b/spec/helper/detect_os/esxi_spec.rb
@@ -2,13 +2,21 @@ require 'spec_helper'
 require 'specinfra/helper/detect_os/esxi'
 
 describe Specinfra::Helper::DetectOs::Esxi do
+  esxi = Specinfra::Helper::DetectOs::Esxi.new(:exec)
   it 'Should return esxi when esxi is installed.' do
-    allow(Specinfra::Helper::DetectOs::Esxi).to receive(:run_command) { CommandResult.new(:stdout => 'VMware ESXi 5.0.0 build-123445', :exit_status => 0) }
-    expect(Specinfra::Helper::DetectOs::Esxi.detect).to include(:family => 'esxi', :release => '5.0.0 build-123445')
+    allow(esxi).to receive(:run_command) {
+      CommandResult.new(:stdout => 'VMware ESXi 5.0.0 build-123445', :exit_status => 0)
+    }
+    expect(esxi.detect).to include(
+      :family  => 'esxi',
+      :release => '5.0.0 build-123445'
+    )
   end
 
   it 'Should not return esxi when VMware Workstation is installed.' do
-    allow(Specinfra::Helper::DetectOs::Esxi).to receive(:run_command) { CommandResult.new(:stdout => 'VMware Workstation', :exit_status => 0) }
-    expect(Specinfra::Helper::DetectOs::Esxi.detect).to be_nil
+    allow(esxi).to receive(:run_command) {
+      CommandResult.new(:stdout => 'VMware Workstation', :exit_status => 0)
+    }
+    expect(esxi.detect).to be_nil
   end
 end

--- a/spec/helper/detect_os/freebsd_spec.rb
+++ b/spec/helper/detect_os/freebsd_spec.rb
@@ -3,13 +3,13 @@ require 'specinfra/helper/detect_os/freebsd'
 
 describe Specinfra::Helper::DetectOs::Freebsd do
   freebsd = Specinfra::Helper::DetectOs::Freebsd.new(:exec)
-  it 'Should return freebsd 8 when FreeBSD 8.2-RELEASE-p3 is installed.' do
+  it 'Should return freebsd 10 when FreeBSD 10.1-RELEASE is installed.' do
     allow(freebsd).to receive(:run_command) {
-      CommandResult.new(:stdout => 'FreeBSD 8.2-RELEASE-p3', :exit_status => 0)
+      CommandResult.new(:stdout => 'FreeBSD 10.1--RELEASE', :exit_status => 0)
     }
     expect(freebsd.detect).to include(
       :family  => 'freebsd',
-      :release => '8'
+      :release => '10'
     )
   end
   it 'Should return freebsd 9 when FreeBSD 9.3-RELEASE is installed.' do
@@ -21,13 +21,22 @@ describe Specinfra::Helper::DetectOs::Freebsd do
       :release => '9'
     )
   end
-  it 'Should return freebsd 10 when FreeBSD 10.1-RELEASE is installed.' do
+  it 'Should return freebsd 8 when FreeBSD 8.2-RELEASE-p3 is installed.' do
     allow(freebsd).to receive(:run_command) {
-      CommandResult.new(:stdout => 'FreeBSD 10.1--RELEASE', :exit_status => 0)
+      CommandResult.new(:stdout => 'FreeBSD 8.2-RELEASE-p3', :exit_status => 0)
     }
     expect(freebsd.detect).to include(
       :family  => 'freebsd',
-      :release => '10'
+      :release => '8'
+    )
+  end
+  it 'Should return freebsd nil when FreeBSD FooBar is installed.' do
+    allow(freebsd).to receive(:run_command) {
+      CommandResult.new(:stdout => 'FreeBSD FooBar', :exit_status => 0)
+    }
+    expect(freebsd.detect).to include(
+      :family  => 'freebsd',
+      :release => nil 
     )
   end
 end


### PR DESCRIPTION
Small cleanups and standardizations around the unit tests, Plus making the darwin os detection cope with bogus input. 