### PR TITLE
Support custom stdout and stderr handler

### DIFF
--- a/lib/specinfra/backend/base.rb
+++ b/lib/specinfra/backend/base.rb
@@ -43,11 +43,11 @@ module Specinfra
         @example = e
       end
 
-      def set_stdout_handler(&block)
+      def stdout_handler=(block)
         @stdout_handler = block
       end
 
-      def set_stderr_handler(&block)
+      def stderr_handler=(block)
         @stderr_handler = block
       end
     end

--- a/lib/specinfra/backend/base.rb
+++ b/lib/specinfra/backend/base.rb
@@ -42,6 +42,14 @@ module Specinfra
       def set_example(e)
         @example = e
       end
+
+      def set_stdout_handler(&block)
+        @stdout_handler = block
+      end
+
+      def set_stderr_handler(&block)
+        @stderr_handler = block
+      end
     end
   end
 end

--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -57,11 +57,15 @@ module Specinfra
                 readable_ios, = IO.select([quit_r, out_r, err_r])
 
                 if readable_ios.include?(out_r)
-                  stdout += out_r.read_nonblock(1000)
+                  out = out_r.read_nonblock(1000)
+                  stdout += out
+                  @stdout_handler.call(out) if @stdout_handler
                 end
 
                 if readable_ios.include?(err_r)
-                  stderr +=  err_r.read_nonblock(1000)
+                  err = err_r.read_nonblock(1000)
+                  stderr += err
+                  @stderr_handler.call(err) if @stderr_handler
                 end
 
                 if readable_ios.include?(quit_r)

--- a/lib/specinfra/backend/ssh.rb
+++ b/lib/specinfra/backend/ssh.rb
@@ -126,6 +126,7 @@ module Specinfra
                 channel.send_data "#{get_config(:sudo_password)}\n"
               else
                 stdout_data += data
+                @stdout_handler.call(data) if @stdout_handler
               end
             end
 
@@ -138,6 +139,7 @@ module Specinfra
                 abort 'Please set sudo password to Specinfra.configuration.sudo_password.'
               else
                 stderr_data += data
+                @stderr_handler.call(data) if @stderr_handler
               end
             end
 


### PR DESCRIPTION
You can define your stdout and stderr handler like this.

```ruby
backend = Specinfra::Backend::Exec.new

backend.stdout_handler = Proc.new {|out| $stdout.write out }

backend.stderr_handler = Proc.new {|err| $stderr.write err }

backend.run_command('ls -al')
```