### PR TITLE
Increase max size of read_noblock() to avoid truncating of output

### DIFF
--- a/lib/specinfra/backend/exec.rb
+++ b/lib/specinfra/backend/exec.rb
@@ -57,13 +57,13 @@ module Specinfra
                 readable_ios, = IO.select([quit_r, out_r, err_r])
 
                 if readable_ios.include?(out_r)
-                  out = out_r.read_nonblock(1000)
+                  out = out_r.read_nonblock(4096)
                   stdout += out
                   @stdout_handler.call(out) if @stdout_handler
                 end
 
                 if readable_ios.include?(err_r)
-                  err = err_r.read_nonblock(1000)
+                  err = err_r.read_nonblock(4096)
                   stderr += err
                   @stderr_handler.call(err) if @stderr_handler
                 end


### PR DESCRIPTION
Sometimes outputs seems to be truncated randomly. Increasing max size of read_nonblock() seems to fix this problem.
