### PR TITLE
Add openstack, vmware and vbox to virtualisation inventory value

### DIFF
--- a/lib/specinfra/host_inventory/virtualization.rb
+++ b/lib/specinfra/host_inventory/virtualization.rb
@@ -6,6 +6,29 @@ module Specinfra
         if backend.run_command('ls /.dockerinit').success?
           res[:system] = 'docker'
         end
+
+        if backend.run_command('ls /usr/sbin/dmidecode').success?
+          ret = backend.run_command('dmidecode')
+          if ret.exit_status == 0
+            case ret.stdout
+            when /Manufacturer: VMware/
+              if ret.stdout =~ /Product Name: VMware Virtual Platform/
+                res[:system] = 'vmware'
+              end
+            when /Manufacturer: Oracle Corporation/
+              if ret.stdout =~ /Product Name: VirtualBox/
+                res[:system] = 'vbox'
+              end
+            when /Product Name: OpenStack/
+              res[:system] = 'openstack'
+            else
+              nil
+            end
+          else
+            nil
+          end
+        end
+
         res
       end
     end


### PR DESCRIPTION
I've added new virtualisation system value in  `host_inventory` such as openstack, vmware and virtualbox, because I want to use serverspec tests for different virtualisation environment.