### PR TITLE
replace netstat with ss for debian port checking

### DIFF
--- a/lib/specinfra/command.rb
+++ b/lib/specinfra/command.rb
@@ -154,6 +154,7 @@ require 'specinfra/command/darwin/base/user'
 require 'specinfra/command/debian'
 require 'specinfra/command/debian/base'
 require 'specinfra/command/debian/base/package'
+require 'specinfra/command/debian/base/port'
 require 'specinfra/command/debian/base/ppa'
 require 'specinfra/command/debian/base/service'
 

--- a/lib/specinfra/command/debian/base/port.rb
+++ b/lib/specinfra/command/debian/base/port.rb
@@ -1,0 +1,5 @@
+class Specinfra::Command::Debian::Base::Port < Specinfra::Command::Base::Port
+  class << self
+    include Specinfra::Command::Module::Ss
+  end
+end

--- a/spec/command/debian/port_spec.rb
+++ b/spec/command/debian/port_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+property[:os] = nil
+set :os, :family => 'debian'
+
+describe get_command(:check_port_is_listening, '80') do
+  it { should eq 'ss -tunl | grep -- :80\ ' }
+end


### PR DESCRIPTION
Follows #445 which implemented the base SS module.

I had tried this in #375 unsuccessfully, but thanks to @tacahilo this was really simple to implement.