### PR TITLE
Add download-file to base commands

### DIFF
--- a/lib/specinfra/command/base/file.rb
+++ b/lib/specinfra/command/base/file.rb
@@ -171,5 +171,9 @@ class Specinfra::Command::Base::File < Specinfra::Command::Base
     def remove(file)
       "rm -rf #{escape(file)}"
     end
+
+    def download(src, dest)
+      "curl -sSL #{escape(src)} -o #{escape(dest)}"
+    end
   end
 end

--- a/spec/command/base/file_spec.rb
+++ b/spec/command/base/file_spec.rb
@@ -85,3 +85,7 @@ end
 describe get_command(:get_file_size, '/tmp') do
   it { should eq 'stat -c %s /tmp' }
 end
+
+describe get_command(:download_file, 'http://example.com/sample_file', '/tmp/sample_file') do
+  it { should eq 'curl -sSL http://example.com/sample_file -o /tmp/sample_file' }
+end


### PR DESCRIPTION
This is a little opinionated feature.

I'd like to use it to update `remote_file` resource of [Itamae](https://github.com/itamae-kitchen/itamae) like following:

```ruby
remote_file '/path/to/file' do
  source 'http://path.to/file' # network download
end
```